### PR TITLE
View capabilities in create edit role, role details

### DIFF
--- a/src/settings/components/CreateEditRole/CreateEditRole.js
+++ b/src/settings/components/CreateEditRole/CreateEditRole.js
@@ -18,11 +18,10 @@ import {
 } from '@folio/stripes/components';
 import PropTypes from 'prop-types';
 
-/* Capabilities api is going to be changed and there are US to be done for capabilities
-import useCapabilities from '../../../hooks/useCapabilities';
-import { CapabilitiesSection } from '../Capabilities/CapabilitiesSection';
-import { getKeyBasedArrayGroup } from '../../utils'; */
 import css from '../../style.css';
+import { CapabilitiesSection } from '../Capabilities/CapabilitiesSection';
+import { getKeyBasedArrayGroup } from '../../utils';
+import useCapabilities from '../../../hooks/useCapabilities';
 
 const CreateEditRole = ({ refetch, selectedRole }) => {
   const ky = useOkapiKy();
@@ -33,6 +32,8 @@ const CreateEditRole = ({ refetch, selectedRole }) => {
 
   const [roleName, setRoleName] = useState('');
   const [description, setDescription] = useState('');
+
+  const { data } = useCapabilities();
 
   const defineCrudOperationTitleId = () => (selectedRole ? 'ui-authorization-roles.crud.editRole' : 'ui-authorization-roles.crud.createRole');
 
@@ -138,7 +139,10 @@ const CreateEditRole = ({ refetch, selectedRole }) => {
                   <Pluggable type="select-application" renderTrigger={props => <Button icon="plus-sign" {...props}><FormattedMessage id="ui-authorization-roles.crud.addApplication" /></Button>} />
                 }
               >
-                <></>
+                <CapabilitiesSection
+                  readOnly
+                  capabilities={getKeyBasedArrayGroup(data, 'type')}
+                />
               </Accordion>
             </AccordionSet>
           </AccordionStatus>

--- a/src/settings/components/RoleDetails/context/RoleDetailsContext/RoleDetailsContextProvider.js
+++ b/src/settings/components/RoleDetails/context/RoleDetailsContext/RoleDetailsContextProvider.js
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { cloneDeep, isEmpty } from 'lodash';
+import React from 'react';
 
 import PropTypes from 'prop-types';
 import { RoleDetailsContext } from './RoleDetailsContext';
@@ -7,39 +6,10 @@ import { getKeyBasedArrayGroup } from '../../../../utils';
 import { capabilitiesPropType } from '../../../../types';
 
 const RoleDetailsContextProvider = ({ role, capabilitiesList, children }) => {
-  const [capabilitiesData, setCapabilitiesData] = useState({ capabilities: {}, capabilitiesTotalCount:0 });
-
-  useEffect(() => {
-    if (!isEmpty(capabilitiesList)) {
-      const copyOfCapabilities = cloneDeep(capabilitiesList);
-
-      copyOfCapabilities.forEach((capability) => {
-        if (role.capabilities.includes(capability.id)) {
-          capability.actions[capability.action] = true;
-        }
-
-        capability.allParentIds?.forEach((parentId) => {
-          if (role.capabilities.includes(parentId)) {
-            capability.actions[capability.action] = true;
-          }
-        });
-      });
-
-      const checkedCapabilitiesCount = copyOfCapabilities.reduce((acc, capability) => {
-        // eslint-disable-next-line no-param-reassign
-        acc += Object.values(capability.actions).filter(bool => bool).length;
-        return acc;
-      }, 0);
-
-      setCapabilitiesData({ capabilities: getKeyBasedArrayGroup(copyOfCapabilities, 'type'),
-        capabilitiesTotalCount: checkedCapabilitiesCount });
-    }
-  }, [role, capabilitiesList]);
-
   return <RoleDetailsContext.Provider
     value={{ role,
-      capabilitiesTotalCount: capabilitiesData.capabilitiesTotalCount,
-      capabilities:  capabilitiesData.capabilities }}
+      capabilitiesTotalCount: role?.capabilities?.length || 0,
+      capabilities:  getKeyBasedArrayGroup(capabilitiesList, 'type') }}
   >
     {children}
   </RoleDetailsContext.Provider>;


### PR DESCRIPTION
 # Capabilities view list 
The tables are read only, the next step is to make them interactive by assigning capabilities to roles 

<img width="916" alt="Screenshot 2023-12-07 at 20 54 55" src="https://github.com/folio-org/ui-authorization-roles/assets/121284650/ff648cec-f3b3-4d99-b1a2-e307e3ac8a4f">
<img width="1048" alt="Screenshot 2023-12-07 at 20 56 22" src="https://github.com/folio-org/ui-authorization-roles/assets/121284650/3f37ce84-7612-45ff-b848-763fb95e9c13">
<img width="706" alt="Screenshot 2023-12-07 at 20 55 34" src="https://github.com/folio-org/ui-authorization-roles/assets/121284650/3efd131f-d99e-4ee1-808a-1af6d432b20a">

