### PR TITLE
UIROLES-2: secondary sort and group capabilties by resource

### DIFF
--- a/src/hooks/useCapabilities.js
+++ b/src/hooks/useCapabilities.js
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useQuery } from 'react-query';
 
 import { useNamespace, useOkapiKy, useStripes } from '@folio/stripes/core';
-import { getKeyBasedArrayGroup } from '../settings/utils';
+import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
 const useCapabilities = () => {
   const ky = useOkapiKy();
@@ -14,15 +14,11 @@ const useCapabilities = () => {
     () => ky.get(`capabilities?limit=${stripes.config.maxUnpagedResourceCount}&query=cql.allRecords=1 sortby resource`).json(),
   );
 
-  const memoizedCapabilitiesList = useMemo(() => {
-    return data?.capabilities || [];
-  }, [data]);
-
   const groupedCapabilitiesByType = useMemo(() => {
-    return getKeyBasedArrayGroup(data?.capabilities || [], 'type');
+    return getCapabilitiesGroupedByTypeAndResource(data?.capabilities || []);
   }, [data]);
 
-  return { capabilitiesList: memoizedCapabilitiesList || [],
+  return { capabilitiesList: data?.capabilities || [],
     groupedCapabilitiesByType,
     isSuccess };
 };

--- a/src/hooks/useCapabilities.test.js
+++ b/src/hooks/useCapabilities.test.js
@@ -14,12 +14,19 @@ const wrapper = ({ children }) => (
   </QueryClientProvider>
 );
 
-const data = { capabilities: [{ id: '1', type: 'settings' }, { id: '2', type: 'procedural' }, { id: '3', type: 'data' }] };
+const data = { capabilities: [{ id: '1', type: 'settings', action: 'manage', resource: 'Capability Roles', applicationId: 'application-01' },
+  { id: '2', type: 'settings', action: 'view', resource: 'Capability Roles', applicationId: 'application-01' },
+  { id: '3', type: 'settings', action: 'edit', resource: 'Capability Roles', applicationId: 'application-01' },
+  { id: '11', type: 'data', action: 'create', resource: 'Capability data', applicationId: 'application-01' },
+  { id: '22', type: 'data', action: 'delete', resource: 'Capability data', applicationId: 'application-01' },
+  { id: '33', type: 'data', action: 'manage', resource: 'Capability data', applicationId: 'application-01' },
+  { id: '111', type: 'procedural', action: 'execute', resource: 'Capability procedural', applicationId: 'application-01' },
+] };
 
 const expectedGroupedCapabilitiesByType = {
-  settings: [{ id: '1', type: 'settings' }],
-  procedural: [{ id: '2', type: 'procedural' }],
-  data: [{ id: '3', type: 'data' }],
+  settings: [{ id: '1', applicationId: 'application-01', resource: 'Capability Roles', actions: { manage: '1', view: '2', edit: '3' } }],
+  data: [{ id: '11', applicationId: 'application-01', resource: 'Capability data', actions: { create: '11', delete: '22', manage: '33' } }],
+  procedural: [{ id: '111', applicationId: 'application-01', resource: 'Capability procedural', actions: { execute: '111' } }],
 };
 describe('useRoleById', () => {
   const mockGet = jest.fn(() => ({

--- a/src/settings/components/Capabilities/CapabilitiesDataType.test.js
+++ b/src/settings/components/Capabilities/CapabilitiesDataType.test.js
@@ -15,6 +15,7 @@ const dataTypeCapabilities = [
     action: 'create',
     type: 'data',
     permissions: ['foo.item.post'],
+    actions: { view: 'view-id', create: 'create-id', edit: 'edit-id', delete: 'delete-id' },
   },
 ];
 
@@ -38,7 +39,7 @@ describe('Data capabilities type', () => {
     const mockChangeHandler = jest.fn();
     const { getAllByRole } = renderComponent(dataTypeCapabilities, mockChangeHandler);
 
-    expect(getAllByRole('checkbox')).toHaveLength(1);
+    expect(getAllByRole('checkbox')).toHaveLength(4);
     expect(getAllByRole('checkbox')[0]).toBeChecked();
 
     await userEvent.click(getAllByRole('checkbox')[0]);

--- a/src/settings/components/Capabilities/CapabilitiesProcedural.test.js
+++ b/src/settings/components/Capabilities/CapabilitiesProcedural.test.js
@@ -15,6 +15,7 @@ const proceduralTypeCapabilities = [
     action: 'execute',
     type: 'procedural',
     permissions: ['foo.item.post'],
+    actions: { execute: 'execute-id' },
   },
 ];
 
@@ -47,7 +48,7 @@ describe('Procedural capabilities type', () => {
 
   it('renders null if action name is not execute', async () => {
     const mockChangeHandler = jest.fn().mockReturnValue(true);
-    const { queryAllByRole } = renderComponent([{ ...proceduralTypeCapabilities[0], action: 'view' }], mockChangeHandler);
+    const { queryAllByRole } = renderComponent([{ ...proceduralTypeCapabilities[0], actions: { view:'view-id' } }], mockChangeHandler);
 
     expect(queryAllByRole('checkbox')).toHaveLength(0);
   });

--- a/src/settings/components/Capabilities/CapabilitiesSection.js
+++ b/src/settings/components/Capabilities/CapabilitiesSection.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { FormattedMessage } from 'react-intl';
 
+import { isEmpty } from 'lodash';
 import { CapabilitiesSettings } from './CapabilitiesSettings';
 import { CapabilitiesProcedural } from './CapabilitiesProcedural';
 import { CapabilitiesDataType } from './CapabilitiesDataType';
@@ -19,9 +20,9 @@ import { CapabilitiesDataType } from './CapabilitiesDataType';
 
 const CapabilitiesSection = ({ capabilities, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected }) => {
   return <section>
-    {capabilities?.data && <CapabilitiesDataType isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.data} />}
-    {capabilities?.settings && <CapabilitiesSettings isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.settings} />}
-    {capabilities?.procedural && <CapabilitiesProcedural isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.procedural} />}
+    {!isEmpty(capabilities.data) && <CapabilitiesDataType isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.data} />}
+    {!isEmpty(capabilities.settings) && <CapabilitiesSettings isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.settings} />}
+    {!isEmpty(capabilities.procedural) && <CapabilitiesProcedural isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.procedural} />}
     <p id="asterisk-policy-desc"><FormattedMessage id="ui-authorization-roles.details.nonSinglePolicyText" /></p>
   </section>;
 };

--- a/src/settings/components/Capabilities/CapabilitiesSettings.test.js
+++ b/src/settings/components/Capabilities/CapabilitiesSettings.test.js
@@ -15,6 +15,7 @@ const settingsTypeCapabilities = [
     action: 'edit',
     type: 'settings',
     permissions: ['foo.item.post'],
+    actions: { view: 'view-id', edit: 'edit-id', manage: 'manage-id' },
   },
 ];
 
@@ -37,7 +38,7 @@ describe('Settings capabilities type', () => {
     const mockChangeHandler = jest.fn().mockReturnValue(true);
     const { getAllByRole } = renderComponent(settingsTypeCapabilities, mockChangeHandler);
 
-    expect(getAllByRole('checkbox')).toHaveLength(1);
+    expect(getAllByRole('checkbox')).toHaveLength(3);
     expect(getAllByRole('checkbox')[0]).toBeChecked();
 
     await userEvent.click(getAllByRole('checkbox')[0]);
@@ -45,9 +46,9 @@ describe('Settings capabilities type', () => {
     expect(mockChangeHandler).toHaveBeenCalled();
   });
 
-  it('renders null if action name is not execute', async () => {
+  it('renders null if action name is not compatible with view, edit, manage actions', async () => {
     const mockChangeHandler = jest.fn().mockReturnValue(true);
-    const { queryAllByRole } = renderComponent([{ ...settingsTypeCapabilities[0], action: 'execute' }], mockChangeHandler);
+    const { queryAllByRole } = renderComponent([{ ...settingsTypeCapabilities[0], actions: { create: 'create-id' } }], mockChangeHandler);
 
     expect(queryAllByRole('checkbox')).toHaveLength(0);
   });

--- a/src/settings/components/Capabilities/ItemActionCheckbox.js
+++ b/src/settings/components/Capabilities/ItemActionCheckbox.js
@@ -12,29 +12,26 @@ const ItemActionCheckbox = ({
 }) => {
   const { getCheckboxAriaLabel } = useCheckboxAriaStates();
 
-  if (!readOnly && item.action !== action) return null;
+  if (!readOnly && !item.actions[action]) return null;
+
   return <CheckboxWithAsterisk
     aria-describedby="asterisk-policy-desc"
     aria-label={getCheckboxAriaLabel(action, item.resource)}
-    onChange={event => onChangeCapabilityCheckbox?.(event, item.id)}
+    onChange={event => {
+      onChangeCapabilityCheckbox?.(event, item.actions[action]);
+    }}
     readOnly={readOnly}
-    checked={isCapabilitySelected(item.id) && action === item.action}
+    checked={isCapabilitySelected(item.actions[action])}
   />;
 };
 
 ItemActionCheckbox.propTypes = {
   item: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
     description: PropTypes.string,
     resource: PropTypes.string.isRequired,
-    action: PropTypes.string.isRequired,
     applicationId: PropTypes.string.isRequired,
-    type: PropTypes.string.isRequired,
-    metadata: PropTypes.shape({
-      createdDate: PropTypes.string,
-      modifiedDate: PropTypes.string,
-    }),
+    actions: PropTypes.object
   }),
   action: PropTypes.string.isRequired,
   onChangeCapabilityCheckbox: PropTypes.func,

--- a/src/settings/components/CreateEditRole/CreateRole.test.js
+++ b/src/settings/components/CreateEditRole/CreateRole.test.js
@@ -53,6 +53,7 @@ describe('CreateRole component', () => {
         action: 'edit',
         type: 'settings',
         permissions: ['foo.item.post'],
+        actions: { view: 'foo.item.get', edit: 'foo.item.put', manage: 'foo.item.post' },
       },
     ] },
     isSuccess: true });
@@ -93,12 +94,12 @@ describe('CreateRole component', () => {
   });
 
   it('correctly sets checked state of checkbox', async () => {
-    const { getByRole, getAllByRole } = renderComponent();
+    const { getAllByRole } = renderComponent();
 
-    expect(getAllByRole('checkbox')).toHaveLength(1);
+    expect(getAllByRole('checkbox')).toHaveLength(3);
 
-    await userEvent.click(getByRole('checkbox'));
+    await userEvent.click(getAllByRole('checkbox')[0]);
 
-    expect(getByRole('checkbox')).toBeChecked();
+    expect(getAllByRole('checkbox')[0]).toBeChecked();
   });
 });

--- a/src/settings/components/CreateEditRole/EditRole.test.js
+++ b/src/settings/components/CreateEditRole/EditRole.test.js
@@ -71,10 +71,11 @@ describe('EditRole component', () => {
         action: 'edit',
         type: 'settings',
         permissions: ['foo.item.post'],
+        actions: { view: '8d2da27c-1d56-48b6-9534218d-2bfae6d79dc8', edit: 'ddsfffc-gff-dsgf-9534218d-fdgfdgfdgdfgdfg' },
       },
     ] },
     isSuccess: true });
-    useRoleCapabilities.mockReturnValue({ initialRoleCapabilitiesSelectedMap: { '8d2da27c-1d56-48b6-9534218d-2bfae6d79dc8': true }, isSuccess: true });
+    useRoleCapabilities.mockReturnValue({ initialRoleCapabilitiesSelectedMap: { '8d2da27c-1d56-48b6-9534218d-2bfae6d79dc8': true, 'ddsfffc-gff-dsgf-9534218d-fdgfdgfdgdfgdfg': true }, isSuccess: true });
     useRoleById.mockReturnValue({ roleDetails: { id: '1', name: 'Admin', description: 'Description' }, isSuccess: true });
   });
 
@@ -142,21 +143,21 @@ describe('EditRole component', () => {
   });
 
   it('renders initial checkboxes states correctly', () => {
-    const { getByRole, getAllByRole } = render(renderWithRouter(
+    const { getAllByRole } = render(renderWithRouter(
       <EditRole roleId="1" />
     ));
-    expect(getAllByRole('checkbox')).toHaveLength(1);
+    expect(getAllByRole('checkbox')).toHaveLength(2);
 
-    expect(getByRole('checkbox')).toBeChecked();
+    expect(getAllByRole('checkbox')[0]).toBeChecked();
   });
   it('correctly sets unchecked state of checkbox on click', async () => {
-    const { getByRole, getAllByRole } = render(renderWithRouter(
+    const { getAllByRole } = render(renderWithRouter(
       <EditRole roleId="1" />
     ));
-    expect(getAllByRole('checkbox')).toHaveLength(1);
+    expect(getAllByRole('checkbox')).toHaveLength(2);
 
-    await userEvent.click(getByRole('checkbox'));
+    await userEvent.click(getAllByRole('checkbox')[0]);
 
-    expect(getByRole('checkbox')).not.toBeChecked();
+    expect(getAllByRole('checkbox')[0]).not.toBeChecked();
   });
 });

--- a/src/settings/components/RoleDetails/RoleDetails.test.js
+++ b/src/settings/components/RoleDetails/RoleDetails.test.js
@@ -11,7 +11,7 @@ import { RoleDetailsContextProvider } from './context/RoleDetailsContext';
 import useCapabilities from '../../../hooks/useCapabilities';
 import useRoleCapabilities from '../../../hooks/useRoleCapabilities';
 import useRoleById from '../../../hooks/useRoleById';
-import { getKeyBasedArrayGroup } from '../../utils';
+import { getCapabilitiesGroupedByTypeAndResource } from '../../utils';
 import renderWithRouter from '../../../../test/jest/helpers/renderWithRouter';
 
 jest.mock('../../../hooks/useCapabilities');
@@ -46,8 +46,6 @@ const capabilities = [{
     'role-capabilities.collection.get',
   ],
   type: 'data',
-  directParentIds: [],
-  allParentIds: ['setting-capability-id'],
   metadata: {
     createdDate: '2023-07-14T15:32:15.560+00:00',
     modifiedDate: '2023-07-14T15:32:15.561+00:00',
@@ -66,8 +64,6 @@ const capabilities = [{
     'role-capabilities.collection.get',
   ],
   type: 'settings',
-  directParentIds: [],
-  allParentIds: [],
   metadata: {
     createdDate: '2023-07-14T15:32:15.560+00:00',
     modifiedDate: '2023-07-14T15:32:15.561+00:00',
@@ -86,8 +82,6 @@ const capabilities = [{
     'role-capabilities.collection.get',
   ],
   type: 'procedural',
-  directParentIds: [],
-  allParentIds: [],
   metadata: {
     createdDate: '2023-07-14T15:32:15.560+00:00',
     modifiedDate: '2023-07-14T15:32:15.561+00:00',
@@ -97,7 +91,7 @@ const capabilities = [{
 
 const renderComponent = () => render(
   renderWithRouter(<RoleDetailsContextProvider
-    groupedCapabilitiesByType={getKeyBasedArrayGroup(capabilities, 'type')}
+    groupedCapabilitiesByType={getCapabilitiesGroupedByTypeAndResource(capabilities)}
   >
     <RoleDetails onClose={onClose} roleId="1" />
   </RoleDetailsContextProvider>)

--- a/src/settings/types/index.js
+++ b/src/settings/types/index.js
@@ -3,15 +3,9 @@ import PropTypes from 'prop-types';
 export const capabilitiesPropType = PropTypes.arrayOf(
   PropTypes.shape({
     id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
     description: PropTypes.string,
     resource: PropTypes.string.isRequired,
-    action: PropTypes.string.isRequired,
     applicationId: PropTypes.string.isRequired,
-    type: PropTypes.string.isRequired,
-    metadata: PropTypes.shape({
-      createdDate: PropTypes.string,
-      modifiedDate: PropTypes.string,
-    }),
+    actions: PropTypes.object
   })
 );

--- a/src/settings/utils/grouping.js
+++ b/src/settings/utils/grouping.js
@@ -112,6 +112,12 @@ const groupCapabilitiesObjectByTypeAndResource = (groupedTypeByResource) => {
     });
   });
 
+  for (const key in result) {
+    if (key in result) {
+      result[key].sort((a, b) => a.applicationId.localeCompare(b.applicationId));
+    }
+  }
+
   return result;
 };
 

--- a/src/settings/utils/grouping.js
+++ b/src/settings/utils/grouping.js
@@ -9,6 +9,70 @@ export const getKeyBasedArrayGroup = (array, key) => {
     return acc;
   }, {});
 };
+
+const groupTypeCapabilityByResource = (data) => Object.entries(data).reduce((acc, [type, capabilities]) => {
+  if (!acc[type]) {
+    acc[type] = {};
+  }
+  acc[type] = capabilities.reduce((initial, capability) => {
+    if (!initial[capability.resource]) {
+      initial[capability.resource] = [];
+    }
+    initial[capability.resource].push(capability);
+
+    return initial;
+  }, {});
+
+  return acc;
+}, {});
+
+const groupCapabilitiesObjectByTypeAndResource = (groupedTypeByResource) => {
+  const dataType = [];
+  const proceduralType = [];
+  const settingsType = [];
+
+  Object.entries(groupedTypeByResource).forEach(([type, capabilities]) => {
+    Object.entries(capabilities).forEach(([resource, cap]) => {
+      const actionsObject = cap.reduce((acc, item) => {
+        acc[item.action] = item.id;
+        return acc;
+      }, {});
+      if (type === 'data') {
+        dataType.push({ id: cap[0].id, applicationId: cap[0].applicationId, resource, actions: actionsObject });
+      } else if (type === 'procedural') {
+        proceduralType.push({ id: cap[0].id, applicationId: cap[0].applicationId, resource, actions: actionsObject });
+      } else if (type === 'settings') {
+        settingsType.push({ id: cap[0].id, applicationId: cap[0].applicationId, resource, actions: actionsObject });
+      }
+    });
+  });
+  const result = {};
+
+  if (dataType.length) {
+    result.data = dataType;
+  }
+  if (proceduralType.length) {
+    result.procedural = proceduralType;
+  }
+  if (settingsType.length) {
+    result.settings = settingsType;
+  }
+
+  return result;
+};
+
+/**
+ * Groups the data by resource.
+ *
+ * @param {Object} data - The data to be grouped.
+ * @returns {Object} - The grouped data.
+ */
+export const getCapabilitiesGroupedByTypeAndResource = (data) => {
+  const typeBasedGroupCapabilities = getKeyBasedArrayGroup(data, 'type');
+  const typesGroupedByResource = groupTypeCapabilityByResource(typeBasedGroupCapabilities);
+
+  return groupCapabilitiesObjectByTypeAndResource(typesGroupedByResource);
+};
 export const groupById = (arr) => {
   return arr.reduce((acc, value) => {
     acc[value.id] = value;

--- a/src/settings/utils/grouping.test.js
+++ b/src/settings/utils/grouping.test.js
@@ -1,4 +1,4 @@
-import { groupById, getKeyBasedArrayGroup } from './grouping';
+import { groupById, getKeyBasedArrayGroup, getCapabilitiesGroupedByTypeAndResource } from './grouping';
 
 describe('Test grouping functions', () => {
   it('test groupById', () => {
@@ -25,5 +25,29 @@ describe('Test grouping functions', () => {
         { id: 4, name: 'Rally', type: 'post' }],
       'put': [{ id: 5, name: 'Nolan', type: 'put' }]
     });
+  });
+
+  it('test getCapabilitiesGroupedByTypeAndResource', () => {
+    const capabilities = [
+      { id: 1, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'edit' },
+      { id: 2, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'create' },
+      { id: 3, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'delete' },
+      { id: 4, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'manage' },
+      { id: 5, applicationId: 'app1', type: 'settings', resource: 'resource2', action: 'edit' },
+      { id: 6, applicationId: 'app1', type: 'settings', resource: 'resource2', action: 'delete' },
+      { id: 7, applicationId: 'app1', type: 'procedural', resource: 'resource3', action: 'execute' },
+      { id: 8, applicationId: 'app1', type: 'procedural', resource: 'resource1', action: 'execute' },
+    ];
+
+    const expected = {
+      data: [{ id: 1, applicationId: 'app1', resource: 'resource1', actions: { edit: 1, create: 2, delete: 3, manage: 4 } }],
+      settings: [{ id: 5, applicationId: 'app1', resource: 'resource2', actions: { edit: 5, delete: 6 } }],
+      procedural: [
+        { id: 7, applicationId: 'app1', resource: 'resource3', actions: { execute: 7 } },
+        { id: 8, applicationId: 'app1', resource: 'resource1', actions: { execute: 8 } },
+      ]
+    };
+
+    expect(getCapabilitiesGroupedByTypeAndResource(capabilities)).toEqual(expected);
   });
 });

--- a/src/settings/utils/grouping.test.js
+++ b/src/settings/utils/grouping.test.js
@@ -31,20 +31,27 @@ describe('Test grouping functions', () => {
     const capabilities = [
       { id: 1, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'edit' },
       { id: 2, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'create' },
+      { id: 22, applicationId: 'ccc', type: 'data', resource: 'resource1', action: 'manage' },
+      { id: 222, applicationId: 'ccc', type: 'data', resource: 'resource1', action: 'delete' },
       { id: 3, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'delete' },
       { id: 4, applicationId: 'app1', type: 'data', resource: 'resource1', action: 'manage' },
       { id: 5, applicationId: 'app1', type: 'settings', resource: 'resource2', action: 'edit' },
       { id: 6, applicationId: 'app1', type: 'settings', resource: 'resource2', action: 'delete' },
       { id: 7, applicationId: 'app1', type: 'procedural', resource: 'resource3', action: 'execute' },
       { id: 8, applicationId: 'app1', type: 'procedural', resource: 'resource1', action: 'execute' },
+      { id: 9, applicationId: 'bbb', type: 'procedural', resource: 'resource3', action: 'execute' },
+      { id: 10, applicationId: 'bbb', type: 'procedural', resource: 'resource3', action: 'delete' },
     ];
 
     const expected = {
-      data: [{ id: 1, applicationId: 'app1', resource: 'resource1', actions: { edit: 1, create: 2, delete: 3, manage: 4 } }],
+      data: [{ id: 1, applicationId: 'app1', resource: 'resource1', actions: { edit: 1, create: 2, delete: 3, manage: 4 } },
+        { id: 22, applicationId: 'ccc', resource: 'resource1', actions: { manage: 22, delete: 222 } },
+      ],
       settings: [{ id: 5, applicationId: 'app1', resource: 'resource2', actions: { edit: 5, delete: 6 } }],
       procedural: [
         { id: 7, applicationId: 'app1', resource: 'resource3', actions: { execute: 7 } },
         { id: 8, applicationId: 'app1', resource: 'resource1', actions: { execute: 8 } },
+        { id: 9, applicationId: 'bbb', resource: 'resource3', actions: { execute: 9, delete: 10 } },
       ]
     };
 

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -5,3 +5,4 @@ import './stripesIcon.mock';
 import './stripesSmartComponents.mock';
 import './stripesComponents.mock';
 import './intl.mock';
+import './resizeObserver.mock';

--- a/test/jest/__mock__/resizeObserver.mock.js
+++ b/test/jest/__mock__/resizeObserver.mock.js
@@ -1,0 +1,5 @@
+global.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));


### PR DESCRIPTION
Currently, there are multiple rows for the same resource and different actions. The purpose of this PR is to group them to one row. 

<img width="903" alt="Screenshot 2024-01-08 at 13 04 04" src="https://github.com/folio-org/ui-authorization-roles/assets/121284650/0d813432-814b-4bee-804d-f19326c94a4f">
<img width="893" alt="Screenshot 2024-01-08 at 13 07 02" src="https://github.com/folio-org/ui-authorization-roles/assets/121284650/3cb15a2c-4617-4789-ae69-643818da2e04">
