### PR TITLE
UIROLES-47 retrieve up to 5000 capabilities at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 * First release.
 * List users assigned to a given role. Refs UIROLES-31.
+* Retrieve up to 5000 capabilities at once. Refs UIROLES-47.

--- a/src/hooks/constants.js
+++ b/src/hooks/constants.js
@@ -1,0 +1,4 @@
+// how many capabilites to retrieve in one swell foop.
+// the default stripes limit is too small but it doesn't feel like
+// raising that value application-wide is appropriate.
+export const CAPABILITES_LIMIT = 5000;

--- a/src/hooks/useApplicationCapabilities.js
+++ b/src/hooks/useApplicationCapabilities.js
@@ -2,13 +2,9 @@ import { useState } from 'react';
 
 import { useOkapiKy } from '@folio/stripes/core';
 import { isEmpty } from 'lodash';
-import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
-// how many capabilites to retrieve in one swell foop.
-// the default stripes limit is too small but it doesn't feel like
-// raising that value application-wide is appropriate.
-// see also useCapabilites which implements an identical constant
-const LIMIT = 5000;
+import { CAPABILITES_LIMIT } from './constants';
+import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
 /**
  * A hook for managing application capabilities.
@@ -37,7 +33,7 @@ const useApplicationCapabilities = () => {
 
   const requestApplicationCapabilitiesList = (listOfIds) => {
     const queryByApplications = listOfIds.map(appId => `applicationId=${appId}`).join(' or ');
-    return ky.get(`capabilities?limit=${LIMIT}&query=${queryByApplications} sortby resource`).json();
+    return ky.get(`capabilities?limit=${CAPABILITES_LIMIT}&query=${queryByApplications} sortby resource`).json();
   };
 
   const onSubmitSelectApplications = async (appIds, onClose) => {

--- a/src/hooks/useApplicationCapabilities.js
+++ b/src/hooks/useApplicationCapabilities.js
@@ -1,8 +1,14 @@
 import { useState } from 'react';
 
-import { useOkapiKy, useStripes } from '@folio/stripes/core';
+import { useOkapiKy } from '@folio/stripes/core';
 import { isEmpty } from 'lodash';
 import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
+
+// how many capabilites to retrieve in one swell foop.
+// the default stripes limit is too small but it doesn't feel like
+// raising that value application-wide is appropriate.
+// see also useCapabilites which implements an identical constant
+const LIMIT = 5000;
 
 /**
  * A hook for managing application capabilities.
@@ -16,7 +22,6 @@ const useApplicationCapabilities = () => {
   const [selectedCapabilitiesMap, setSelectedCapabilitiesMap] = useState({});
 
   const ky = useOkapiKy();
-  const stripes = useStripes();
 
   const roleCapabilitiesListIds = Object.entries(selectedCapabilitiesMap).filter(([, isSelected]) => isSelected).map(([id]) => id);
 
@@ -32,7 +37,7 @@ const useApplicationCapabilities = () => {
 
   const requestApplicationCapabilitiesList = (listOfIds) => {
     const queryByApplications = listOfIds.map(appId => `applicationId=${appId}`).join(' or ');
-    return ky.get(`capabilities?limit=${stripes.config.maxUnpagedResourceCount}&query=${queryByApplications} sortby resource`).json();
+    return ky.get(`capabilities?limit=${LIMIT}&query=${queryByApplications} sortby resource`).json();
   };
 
   const onSubmitSelectApplications = async (appIds, onClose) => {

--- a/src/hooks/useCapabilities.js
+++ b/src/hooks/useCapabilities.js
@@ -2,13 +2,9 @@ import React, { useMemo } from 'react';
 import { useQuery } from 'react-query';
 
 import { useNamespace, useOkapiKy } from '@folio/stripes/core';
-import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
-// how many capabilites to retrieve in one swell foop.
-// the default stripes limit is too small but it doesn't feel like
-// raising that value application-wide is appropriate.
-// see also useApplicationCapabilites which implements an identical constant
-const LIMIT = 5000;
+import { CAPABILITES_LIMIT } from './constants';
+import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
 const useCapabilities = () => {
   const ky = useOkapiKy();
@@ -16,7 +12,7 @@ const useCapabilities = () => {
 
   const { data, isSuccess } = useQuery(
     namespace,
-    () => ky.get(`capabilities?limit=${LIMIT}&query=cql.allRecords=1 sortby resource`).json(),
+    () => ky.get(`capabilities?limit=${CAPABILITES_LIMIT}&query=cql.allRecords=1 sortby resource`).json(),
   );
 
   const groupedCapabilitiesByType = useMemo(() => {

--- a/src/hooks/useCapabilities.js
+++ b/src/hooks/useCapabilities.js
@@ -1,17 +1,22 @@
 import React, { useMemo } from 'react';
 import { useQuery } from 'react-query';
 
-import { useNamespace, useOkapiKy, useStripes } from '@folio/stripes/core';
+import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
+
+// how many capabilites to retrieve in one swell foop.
+// the default stripes limit is too small but it doesn't feel like
+// raising that value application-wide is appropriate.
+// see also useApplicationCapabilites which implements an identical constant
+const LIMIT = 5000;
 
 const useCapabilities = () => {
   const ky = useOkapiKy();
-  const stripes = useStripes();
   const [namespace] = useNamespace({ key: 'capabilities-list' });
 
   const { data, isSuccess } = useQuery(
     namespace,
-    () => ky.get(`capabilities?limit=${stripes.config.maxUnpagedResourceCount}&query=cql.allRecords=1 sortby resource`).json(),
+    () => ky.get(`capabilities?limit=${LIMIT}&query=cql.allRecords=1 sortby resource`).json(),
   );
 
   const groupedCapabilitiesByType = useMemo(() => {

--- a/src/hooks/useRoleCapabilities.js
+++ b/src/hooks/useRoleCapabilities.js
@@ -1,16 +1,17 @@
 import React, { useMemo } from 'react';
 import { useQuery } from 'react-query';
 
-import { useNamespace, useOkapiKy, useStripes } from '@folio/stripes/core';
+import { useNamespace, useOkapiKy } from '@folio/stripes/core';
+
+import { CAPABILITES_LIMIT } from './constants';
 import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
 const useRoleCapabilities = (roleId) => {
   const ky = useOkapiKy();
-  const stripes = useStripes();
   const [namespace] = useNamespace({ key: 'role-capabilities-list' });
 
   const { data, isSuccess } = useQuery([namespace, roleId],
-    () => ky.get(`roles/${roleId}/capabilities?limit=${stripes.config.maxUnpagedResourceCount}`).json(),
+    () => ky.get(`roles/${roleId}/capabilities?limit=${CAPABILITES_LIMIT}`).json(),
     { enabled: !!roleId,
       placeholderData: {
         capabilities: [], totalRecords: 0


### PR DESCRIPTION
* set `limit` in all three queries for capabilities (whoops, missed one
  in #23)
* share a single constant, `CAPABILITIES_LIMIT`

Refs [UIROLES-47](https://folio-org.atlassian.net/browse/UIROLES-47)