### PR TITLE
UIROLES-40: Incorporate CapabilitySets

### DIFF
--- a/src/hooks/useApplicationCapabilities.js
+++ b/src/hooks/useApplicationCapabilities.js
@@ -30,6 +30,7 @@ const useApplicationCapabilities = () => {
   const ky = useOkapiKy();
 
   const roleCapabilitiesListIds = Object.entries(selectedCapabilitiesMap).filter(([, isSelected]) => isSelected).map(([id]) => id);
+  const roleCapabilitySetsListIds = Object.entries(selectedCapabilitiesMap).filter(([, isSelected]) => isSelected).map(([id]) => id);
 
   const getOnlyIntersectedWithApplicationsCapabilities = (applicationCaps) => {
     if (isEmpty(applicationCaps)) return {};
@@ -106,7 +107,8 @@ const useApplicationCapabilities = () => {
     setSelectedCapabilitySetsMap,
     disabledCapabilities,
     setDisabledCapabilities,
-    capabilitySetsList };
+    capabilitySetsList,
+    roleCapabilitySetsListIds };
 };
 
 export default useApplicationCapabilities;

--- a/src/hooks/useCapabilities.test.js
+++ b/src/hooks/useCapabilities.test.js
@@ -28,7 +28,7 @@ const expectedGroupedCapabilitiesByType = {
   data: [{ id: '11', applicationId: 'application-01', resource: 'Capability data', actions: { create: '11', delete: '22', manage: '33' } }],
   procedural: [{ id: '111', applicationId: 'application-01', resource: 'Capability procedural', actions: { execute: '111' } }],
 };
-describe('useRoleById', () => {
+describe('useCapabilities', () => {
   const mockGet = jest.fn(() => ({
     json: () => Promise.resolve(data),
   }));

--- a/src/hooks/useCapabilitySets.js
+++ b/src/hooks/useCapabilitySets.js
@@ -1,24 +1,20 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useQuery } from 'react-query';
 
-import { useNamespace, useOkapiKy, useStripes } from '@folio/stripes/core';
-import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
+import { useNamespace, useOkapiKy } from '@folio/stripes/core';
+
+const LIMIT = 5000;
 
 const useCapabilitySets = () => {
   const ky = useOkapiKy();
-  const stripes = useStripes();
   const [namespace] = useNamespace({ key: 'capability-sets' });
 
   const { data, isSuccess } = useQuery(
     namespace,
-    () => ky.get(`capability-sets?limit=${stripes.config.maxUnpagedResourceCount}&query=cql.allRecords=1 sortby resource`).json(),
+    () => ky.get(`capability-sets?limit=${LIMIT}&query=cql.allRecords=1 sortby resource`).json(),
   );
 
-  const groupedCapabilitiesByType = useMemo(() => {
-    return getCapabilitiesGroupedByTypeAndResource(data?.capabilitySets || []);
-  }, [data]);
-
-  return { groupedCapabilitiesByType, data, isSuccess };
+  return { data, isSuccess };
 };
 
 export default useCapabilitySets;

--- a/src/hooks/useCapabilitySets.js
+++ b/src/hooks/useCapabilitySets.js
@@ -1,0 +1,24 @@
+import React, { useMemo } from 'react';
+import { useQuery } from 'react-query';
+
+import { useNamespace, useOkapiKy, useStripes } from '@folio/stripes/core';
+import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
+
+const useCapabilitySets = () => {
+  const ky = useOkapiKy();
+  const stripes = useStripes();
+  const [namespace] = useNamespace({ key: 'capability-sets' });
+
+  const { data, isSuccess } = useQuery(
+    namespace,
+    () => ky.get(`capability-sets?limit=${stripes.config.maxUnpagedResourceCount}&query=cql.allRecords=1 sortby resource`).json(),
+  );
+
+  const groupedCapabilitiesByType = useMemo(() => {
+    return getCapabilitiesGroupedByTypeAndResource(data?.capabilitySets || []);
+  }, [data]);
+
+  return { groupedCapabilitiesByType, data, isSuccess };
+};
+
+export default useCapabilitySets;

--- a/src/hooks/useCapabilitySets.test.js
+++ b/src/hooks/useCapabilitySets.test.js
@@ -1,0 +1,39 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { act, renderHook } from '@folio/jest-config-stripes/testing-library/react';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import useCapabilitySets from './useCapabilitySets';
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+
+const data = { capabilitySets: [{ id: '1', type: 'settings', action: 'manage', resource: 'Capability Roles', applicationId: 'application-01', capabilities: '222' },
+] };
+
+describe('useCapabilitySet', () => {
+  const mockGet = jest.fn(() => ({
+    json: () => Promise.resolve(data),
+  }));
+
+  beforeEach(() => {
+    queryClient.clear();
+    mockGet.mockClear();
+    useOkapiKy.mockClear().mockReturnValue({
+      get: mockGet,
+    });
+  });
+
+  it('fetches capabilitySets', async () => {
+    const { result } = renderHook(() => useCapabilitySets(), { wrapper });
+    await act(() => result.current.isSuccess);
+
+    expect(result.current.data).toStrictEqual(data);
+    expect(result.current.isSuccess).toBe(true);
+  });
+});

--- a/src/hooks/useCreateRoleMutation.js
+++ b/src/hooks/useCreateRoleMutation.js
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 
-const useCreateRoleMutation = (roleCapabilitiesListIds) => {
+const useCreateRoleMutation = (roleCapabilitiesListIds, capabilitySetListIds) => {
   const ky = useOkapiKy();
   const queryClient = useQueryClient();
   const [namespace] = useNamespace();
@@ -12,7 +12,11 @@ const useCreateRoleMutation = (roleCapabilitiesListIds) => {
       if (roleCapabilitiesListIds.length > 0) {
         await ky.post('roles/capabilities', { json: { roleId:newRole.id, capabilityIds: roleCapabilitiesListIds } }).json();
       }
-    }
+      if (capabilitySetListIds.length > 0) {
+        await ky.post('roles/capability-sets', { json: { roleId:newRole.id, capabilitySetIds: capabilitySetListIds } }).json();
+      }
+    },
+    onError:(error) => console.error(JSON.stringify(error)) // eslint-disable-line no-console
   });
 
   return { mutateRole: mutateAsync, isLoading };

--- a/src/hooks/useCreateRoleMutation.test.js
+++ b/src/hooks/useCreateRoleMutation.test.js
@@ -23,7 +23,7 @@ describe('useCreateRoleMutation', () => {
     });
 
     const { result } = renderHook(
-      () => useCreateRoleMutation(['1', '2', '3']),
+      () => useCreateRoleMutation(['1', '2', '3'], []),
       { wrapper },
     );
 

--- a/src/hooks/useEditRoleMutation.js
+++ b/src/hooks/useEditRoleMutation.js
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
 import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 
-const useEditRoleMutation = ({ id, name, description }, roleCapabilitiesListIds, shouldUpdateCapabilities) => {
+const useEditRoleMutation = ({ id, name, description }, { roleCapabilitiesListIds, shouldUpdateCapabilities, shouldUpdateCapabilitySets, roleCapabilitySetsListIds }) => {
   const ky = useOkapiKy();
   const queryClient = useQueryClient();
   const [namespace] = useNamespace();
@@ -11,8 +11,12 @@ const useEditRoleMutation = ({ id, name, description }, roleCapabilitiesListIds,
       if (shouldUpdateCapabilities) {
         await ky.put(`roles/${id}/capabilities`, { json: { capabilityIds: roleCapabilitiesListIds } });
       }
+      if (shouldUpdateCapabilitySets) {
+        await ky.put(`roles/${id}/capability-sets`, { json: { capabilitySetIds: roleCapabilitySetsListIds } });
+      }
       await queryClient.invalidateQueries(namespace);
     },
+    onError:(error) => console.error(JSON.stringify(error)) // eslint-disable-line no-console
   });
   return { mutateRole: mutateAsync, isLoading };
 };

--- a/src/hooks/useRoleCapabilitySets.js
+++ b/src/hooks/useRoleCapabilitySets.js
@@ -25,7 +25,12 @@ const useRoleCapabilitySets = (roleId) => {
     return getCapabilitiesGroupedByTypeAndResource(data?.capabilitySets || []);
   }, [data]);
 
-  return { initialRoleCapabilitySetsSelectedMap, isSuccess, capabilitySetsTotalCount: data?.totalRecords || 0, groupedRoleCapabilitySetsByType };
+  const capabilitySetsCapabilities = data?.capabilitySets.flatMap(capSet => capSet.capabilities).reduce((obj, item) => {
+    obj[item] = true;
+    return obj;
+  }, {});
+
+  return { initialRoleCapabilitySetsSelectedMap, isSuccess, capabilitySetsTotalCount: data?.totalRecords || 0, groupedRoleCapabilitySetsByType, capabilitySetsCapabilities };
 };
 
 export default useRoleCapabilitySets;

--- a/src/settings/components/Capabilities/CapabilitiesDataType.js
+++ b/src/settings/components/Capabilities/CapabilitiesDataType.js
@@ -8,7 +8,7 @@ import { capabilitiesPropType } from '../../types';
 import { columnTranslations } from '../../../constants/translations';
 import ItemActionCheckbox from './ItemActionCheckbox';
 
-const CapabilitiesDataType = ({ content, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected }) => {
+const CapabilitiesDataType = ({ content, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected, isCapabilityDisabled }) => {
   const { formatMessage } = useIntl();
 
   const columnMapping = {
@@ -39,6 +39,7 @@ const CapabilitiesDataType = ({ content, readOnly, onChangeCapabilityCheckbox, i
     return <ItemActionCheckbox
       action={action}
       readOnly={readOnly}
+      isCapabilityDisabled={isCapabilityDisabled}
       onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
       item={item}
       isCapabilitySelected={isCapabilitySelected}
@@ -93,6 +94,7 @@ const CapabilitiesDataType = ({ content, readOnly, onChangeCapabilityCheckbox, i
 CapabilitiesDataType.propTypes = { content: capabilitiesPropType,
   readOnly: PropTypes.bool,
   onChangeCapabilityCheckbox: PropTypes.func,
-  isCapabilitySelected: PropTypes.func };
+  isCapabilitySelected: PropTypes.func,
+  isCapabilityDisabled: PropTypes.func };
 
 export { CapabilitiesDataType };

--- a/src/settings/components/Capabilities/CapabilitiesProcedural.js
+++ b/src/settings/components/Capabilities/CapabilitiesProcedural.js
@@ -10,7 +10,7 @@ import { columnTranslations } from '../../../constants/translations';
 import css from '../../style.css';
 import ItemActionCheckbox from './ItemActionCheckbox';
 
-const CapabilitiesProcedural = ({ content, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected }) => {
+const CapabilitiesProcedural = ({ content, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected, isCapabilityDisabled }) => {
   const { formatMessage } = useIntl();
 
   const columnMapping = {
@@ -27,6 +27,7 @@ const CapabilitiesProcedural = ({ content, readOnly, onChangeCapabilityCheckbox,
       onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
       item={item}
       isCapabilitySelected={isCapabilitySelected}
+      isCapabilityDisabled={isCapabilityDisabled}
     />;
   };
 
@@ -55,6 +56,7 @@ const CapabilitiesProcedural = ({ content, readOnly, onChangeCapabilityCheckbox,
 CapabilitiesProcedural.propTypes = { content: capabilitiesPropType,
   readOnly: PropTypes.bool,
   onChangeCapabilityCheckbox: PropTypes.func,
-  isCapabilitySelected: PropTypes.func };
+  isCapabilitySelected: PropTypes.func,
+  isCapabilityDisabled: PropTypes.func };
 
 export { CapabilitiesProcedural };

--- a/src/settings/components/Capabilities/CapabilitiesSection.js
+++ b/src/settings/components/Capabilities/CapabilitiesSection.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FormattedMessage } from 'react-intl';
-
 import { isEmpty } from 'lodash';
 import { CapabilitiesSettings } from './CapabilitiesSettings';
 import { CapabilitiesProcedural } from './CapabilitiesProcedural';
@@ -18,18 +16,18 @@ import { CapabilitiesDataType } from './CapabilitiesDataType';
  * @return {JSX.Element} - the rendered CapabilitiesSection component
  */
 
-const CapabilitiesSection = ({ capabilities, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected }) => {
+const CapabilitiesSection = ({ capabilities, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected, isCapabilityDisabled }) => {
   return <section>
-    {!isEmpty(capabilities.data) && <CapabilitiesDataType isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.data} />}
-    {!isEmpty(capabilities.settings) && <CapabilitiesSettings isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.settings} />}
-    {!isEmpty(capabilities.procedural) && <CapabilitiesProcedural isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.procedural} />}
-    <p id="asterisk-policy-desc"><FormattedMessage id="ui-authorization-roles.details.nonSinglePolicyText" /></p>
+    {!isEmpty(capabilities.data) && <CapabilitiesDataType isCapabilityDisabled={isCapabilityDisabled} isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.data} />}
+    {!isEmpty(capabilities.settings) && <CapabilitiesSettings isCapabilityDisabled={isCapabilityDisabled} isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.settings} />}
+    {!isEmpty(capabilities.procedural) && <CapabilitiesProcedural isCapabilityDisabled={isCapabilityDisabled} isCapabilitySelected={isCapabilitySelected} onChangeCapabilityCheckbox={onChangeCapabilityCheckbox} readOnly={readOnly} content={capabilities.procedural} />}
   </section>;
 };
 
 CapabilitiesSection.propTypes = { capabilities: PropTypes.object.isRequired,
   readOnly: PropTypes.bool,
   onChangeCapabilityCheckbox: PropTypes.func,
-  isCapabilitySelected: PropTypes.func };
+  isCapabilitySelected: PropTypes.func,
+  isCapabilityDisabled: PropTypes.func };
 
 export { CapabilitiesSection };

--- a/src/settings/components/Capabilities/CapabilitiesSettings.js
+++ b/src/settings/components/Capabilities/CapabilitiesSettings.js
@@ -11,7 +11,7 @@ import { columnTranslations } from '../../../constants/translations';
 import css from '../../style.css';
 import ItemActionCheckbox from './ItemActionCheckbox';
 
-const CapabilitiesSettings = ({ content, readOnly, onChangeCapabilityCheckbox, isCapabilitySelected }) => {
+const CapabilitiesSettings = ({ content, readOnly, onChangeCapabilityCheckbox, onChangeCapabilitySetCheckBox, isCapabilitySelected, isCapabilityDisabled }) => {
   const { formatMessage } = useIntl();
 
   const columnMapping = {
@@ -39,8 +39,10 @@ const CapabilitiesSettings = ({ content, readOnly, onChangeCapabilityCheckbox, i
       action={action}
       readOnly={readOnly}
       onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
+      onChangeCapabilitySetCheckBox={onChangeCapabilitySetCheckBox}
       item={item}
       isCapabilitySelected={isCapabilitySelected}
+      isCapabilityDisabled={isCapabilityDisabled}
     />;
   };
 
@@ -71,6 +73,8 @@ const CapabilitiesSettings = ({ content, readOnly, onChangeCapabilityCheckbox, i
 CapabilitiesSettings.propTypes = { content: capabilitiesPropType,
   readOnly: PropTypes.bool,
   onChangeCapabilityCheckbox: PropTypes.func,
-  isCapabilitySelected: PropTypes.func };
+  onChangeCapabilitySetCheckBox: PropTypes.func,
+  isCapabilitySelected: PropTypes.func,
+  isCapabilityDisabled: PropTypes.func };
 
 export { CapabilitiesSettings };

--- a/src/settings/components/Capabilities/ItemActionCheckbox.js
+++ b/src/settings/components/Capabilities/ItemActionCheckbox.js
@@ -8,7 +8,8 @@ const ItemActionCheckbox = ({
   action,
   onChangeCapabilityCheckbox,
   readOnly,
-  isCapabilitySelected
+  isCapabilitySelected,
+  isCapabilityDisabled
 }) => {
   const { getCheckboxAriaLabel } = useCheckboxAriaStates();
 
@@ -20,7 +21,7 @@ const ItemActionCheckbox = ({
     onChange={event => {
       onChangeCapabilityCheckbox?.(event, item.actions[action]);
     }}
-    readOnly={readOnly}
+    readOnly={readOnly || isCapabilityDisabled?.(item.actions[action])}
     checked={isCapabilitySelected(item.actions[action])}
   />;
 };
@@ -36,6 +37,7 @@ ItemActionCheckbox.propTypes = {
   action: PropTypes.string.isRequired,
   onChangeCapabilityCheckbox: PropTypes.func,
   readOnly: PropTypes.bool,
-  isCapabilitySelected: PropTypes.func
+  isCapabilitySelected: PropTypes.func,
+  isCapabilityDisabled: PropTypes.func
 };
 export default ItemActionCheckbox;

--- a/src/settings/components/CreateEditRole/CapabilitiesAccordion.js
+++ b/src/settings/components/CreateEditRole/CapabilitiesAccordion.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { FormattedMessage } from 'react-intl';
+import {
+  Accordion,
+  Button,
+} from '@folio/stripes/components';
+import { Pluggable } from '@folio/stripes/core';
+
+import PropTypes from 'prop-types';
+import { CapabilitiesSection } from '../Capabilities/CapabilitiesSection';
+
+
+function CapabilitiesAccordion({ checkedAppIdsMap,
+  onSaveSelectedApplications,
+  isCapabilitySelected,
+  onChangeCapabilityCheckbox,
+  isCapabilityDisabled,
+  capabilities }) {
+  return (
+    <Accordion
+      label={<FormattedMessage id="ui-authorization-roles.details.capabilities" />}
+      displayWhenOpen={
+        <Pluggable
+          type="select-application"
+          checkedAppIdsMap={checkedAppIdsMap}
+          onSave={onSaveSelectedApplications}
+          renderTrigger={props => <Button icon="plus-sign" {...props}><FormattedMessage id="ui-authorization-roles.crud.selectApplication" /></Button>}
+        />
+                }
+    >
+      <CapabilitiesSection
+        readOnly={false}
+        isCapabilitySelected={isCapabilitySelected}
+        onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
+        capabilities={capabilities}
+        isCapabilityDisabled={isCapabilityDisabled}
+      />
+      <p id="asterisk-policy-desc"><FormattedMessage id="ui-authorization-roles.details.nonSinglePolicyText" /></p>
+    </Accordion>
+  );
+}
+
+CapabilitiesAccordion.propTypes = {
+  checkedAppIdsMap:PropTypes.object,
+  onSaveSelectedApplications: PropTypes.func,
+  isCapabilitySelected: PropTypes.func,
+  onChangeCapabilityCheckbox: PropTypes.func,
+  capabilities: PropTypes.object,
+  isCapabilityDisabled:PropTypes.func,
+};
+
+export default CapabilitiesAccordion;

--- a/src/settings/components/CreateEditRole/CapabilitySetAccordion.js
+++ b/src/settings/components/CreateEditRole/CapabilitySetAccordion.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { FormattedMessage } from 'react-intl';
+import {
+  Accordion,
+} from '@folio/stripes/components';
+import PropTypes from 'prop-types';
+import { CapabilitiesSection } from '../Capabilities/CapabilitiesSection';
+
+
+function CapabilitySetAccordion({ isCapabilitySetSelected,
+  onChangeCapabilitySetCheckbox,
+  capabilitySets }) {
+  return (
+    <Accordion
+      label={<FormattedMessage id="ui-authorization-roles.details.capabilitySets" />}
+    >
+      <CapabilitiesSection
+        readOnly={false}
+        isCapabilitySelected={isCapabilitySetSelected}
+        onChangeCapabilityCheckbox={onChangeCapabilitySetCheckbox}
+        capabilities={capabilitySets}
+      />
+    </Accordion>
+  );
+}
+
+CapabilitySetAccordion.propTypes = {
+  isCapabilitySetSelected: PropTypes.func,
+  onChangeCapabilitySetCheckbox: PropTypes.func,
+  capabilitySets: PropTypes.object,
+};
+
+export default CapabilitySetAccordion;

--- a/src/settings/components/CreateEditRole/CreateEditRoleForm.js
+++ b/src/settings/components/CreateEditRole/CreateEditRoleForm.js
@@ -34,7 +34,11 @@ function CreateEditRoleForm({
   onChangeCapabilityCheckbox,
   selectedCapabilitiesMap,
   onSaveSelectedApplications,
-  checkedAppIdsMap
+  checkedAppIdsMap,
+  capabilitySets,
+  isCapabilitySetSelected,
+  onChangeCapabilitySetCheckbox,
+  isCapabilityDisabled
 }) {
   const paneFooterRenderStart = <Button
     marginBottom0
@@ -83,6 +87,18 @@ function CreateEditRoleForm({
                   data-testid="description-input"
                 />
               </Accordion>
+
+              <Accordion
+                label={<FormattedMessage id="ui-authorization-roles.details.capabilitySets" />}
+              >
+                <CapabilitiesSection
+                  readOnly={false}
+                  isCapabilitySelected={isCapabilitySetSelected}
+                  onChangeCapabilityCheckbox={onChangeCapabilitySetCheckbox}
+                  capabilities={capabilitySets}
+                  roleCapabilitiesListIds={selectedCapabilitiesMap}
+                />
+              </Accordion>
               <Accordion
                 label={<FormattedMessage id="ui-authorization-roles.details.capabilities" />}
                 displayWhenOpen={
@@ -100,7 +116,9 @@ function CreateEditRoleForm({
                   onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
                   capabilities={capabilities}
                   roleCapabilitiesListIds={selectedCapabilitiesMap}
+                  isCapabilityDisabled={isCapabilityDisabled}
                 />
+                <p id="asterisk-policy-desc"><FormattedMessage id="ui-authorization-roles.details.nonSinglePolicyText" /></p>
               </Accordion>
             </AccordionSet>
           </AccordionStatus>
@@ -119,11 +137,15 @@ CreateEditRoleForm.propTypes = {
   description: PropTypes.string,
   setDescription: PropTypes.func,
   isCapabilitySelected: PropTypes.func,
+  isCapabilitySetSelected: PropTypes.func,
   onChangeCapabilityCheckbox: PropTypes.func,
   capabilities: PropTypes.object,
+  capabilitySets: PropTypes.object,
   isLoading: PropTypes.bool,
   selectedCapabilitiesMap : PropTypes.object,
   onSaveSelectedApplications: PropTypes.func,
+  onChangeCapabilitySetCheckbox: PropTypes.func,
+  isCapabilityDisabled:PropTypes.func,
   checkedAppIdsMap:PropTypes.object,
 };
 

--- a/src/settings/components/CreateEditRole/CreateEditRoleForm.js
+++ b/src/settings/components/CreateEditRole/CreateEditRoleForm.js
@@ -14,11 +14,11 @@ import {
   TextArea,
   TextField
 } from '@folio/stripes/components';
-import { Pluggable } from '@folio/stripes/core';
 
 import PropTypes from 'prop-types';
-import { CapabilitiesSection } from '../Capabilities/CapabilitiesSection';
 import css from '../../style.css';
+import CapabilitiesAccordion from './CapabilitiesAccordion';
+import CapabilitySetAccordion from './CapabilitySetAccordion';
 
 function CreateEditRoleForm({
   title,
@@ -88,38 +88,20 @@ function CreateEditRoleForm({
                 />
               </Accordion>
 
-              <Accordion
-                label={<FormattedMessage id="ui-authorization-roles.details.capabilitySets" />}
-              >
-                <CapabilitiesSection
-                  readOnly={false}
-                  isCapabilitySelected={isCapabilitySetSelected}
-                  onChangeCapabilityCheckbox={onChangeCapabilitySetCheckbox}
-                  capabilities={capabilitySets}
-                  roleCapabilitiesListIds={selectedCapabilitiesMap}
-                />
-              </Accordion>
-              <Accordion
-                label={<FormattedMessage id="ui-authorization-roles.details.capabilities" />}
-                displayWhenOpen={
-                  <Pluggable
-                    type="select-application"
-                    checkedAppIdsMap={checkedAppIdsMap}
-                    onSave={onSaveSelectedApplications}
-                    renderTrigger={props => <Button icon="plus-sign" {...props}><FormattedMessage id="ui-authorization-roles.crud.selectApplication" /></Button>}
-                  />
-                }
-              >
-                <CapabilitiesSection
-                  readOnly={false}
-                  isCapabilitySelected={isCapabilitySelected}
-                  onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
-                  capabilities={capabilities}
-                  roleCapabilitiesListIds={selectedCapabilitiesMap}
-                  isCapabilityDisabled={isCapabilityDisabled}
-                />
-                <p id="asterisk-policy-desc"><FormattedMessage id="ui-authorization-roles.details.nonSinglePolicyText" /></p>
-              </Accordion>
+              <CapabilitySetAccordion
+                isCapabilitySetSelected={isCapabilitySetSelected}
+                onChangeCapabilitySetCheckbox={onChangeCapabilitySetCheckbox}
+                capabilitySets={capabilitySets}
+              />
+              <CapabilitiesAccordion
+                checkedAppIdsMap={checkedAppIdsMap}
+                onSaveSelectedApplications={onSaveSelectedApplications}
+                isCapabilitySelected={isCapabilitySelected}
+                onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
+                selectedCapabilitiesMap={selectedCapabilitiesMap}
+                isCapabilityDisabled={isCapabilityDisabled}
+                capabilities={capabilities}
+              />
             </AccordionSet>
           </AccordionStatus>
         </Pane>

--- a/src/settings/components/CreateEditRole/CreateRole.js
+++ b/src/settings/components/CreateEditRole/CreateRole.js
@@ -16,11 +16,30 @@ const CreateRole = () => {
     onSubmitSelectApplications,
     capabilities,
     selectedCapabilitiesMap,
-    setSelectedCapabilitiesMap, roleCapabilitiesListIds } = useApplicationCapabilities();
+    setSelectedCapabilitiesMap, roleCapabilitiesListIds,
+    selectedCapabilitySetsMap,
+    setSelectedCapabilitySetsMap,
+    disabledCapabilities,
+    setDisabledCapabilities,
+    capabilitySets,
+    capabilitySetsList } = useApplicationCapabilities();
 
   const onChangeCapabilityCheckbox = (event, id) => setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: event.target.checked });
+  const onChangeCapabilitySetCheckbox = (event, capabilitySetId) => {
+    const selectedCapabilitySet = capabilitySetsList.find(cap => cap.id === capabilitySetId);
+    const capabilitySetsCap = selectedCapabilitySet.capabilities.reduce((obj, item) => {
+      obj[item] = event.target.checked;
+      return obj;
+    }, {});
 
-  const isCapabilitySelected = (id) => !!selectedCapabilitiesMap[id];
+    setDisabledCapabilities({ ...disabledCapabilities, ...capabilitySetsCap });
+    setSelectedCapabilitySetsMap({ ...selectedCapabilitySetsMap, [capabilitySetId]: event.target.checked });
+    setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, ...capabilitySetsCap });
+  };
+
+  const isCapabilitySelected = id => !!selectedCapabilitiesMap[id];
+  const isCapabilitySetSelected = id => !!selectedCapabilitySetsMap[id];
+  const isCapabilityDisabled = id => !!disabledCapabilities[id];
 
   const { mutateRole, isLoading } = useCreateRoleMutation(roleCapabilitiesListIds);
 
@@ -38,12 +57,16 @@ const CreateRole = () => {
     description={description}
     isLoading={isLoading}
     capabilities={capabilities}
+    capabilitySets={capabilitySets}
+    isCapabilityDisabled={isCapabilityDisabled}
+    isCapabilitySetSelected={isCapabilitySetSelected}
     isCapabilitySelected={isCapabilitySelected}
     setRoleName={setRoleName}
     setDescription={setDescription}
     onSubmit={onSubmit}
     onClose={goBack}
     onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
+    onChangeCapabilitySetCheckbox={onChangeCapabilitySetCheckbox}
     selectedCapabilitiesMap={selectedCapabilitiesMap}
     onSaveSelectedApplications={onSubmitSelectApplications}
     checkedAppIdsMap={checkedAppIdsMap}

--- a/src/settings/components/CreateEditRole/CreateRole.js
+++ b/src/settings/components/CreateEditRole/CreateRole.js
@@ -27,6 +27,8 @@ const CreateRole = () => {
   const onChangeCapabilityCheckbox = (event, id) => setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: event.target.checked });
   const onChangeCapabilitySetCheckbox = (event, capabilitySetId) => {
     const selectedCapabilitySet = capabilitySetsList.find(cap => cap.id === capabilitySetId);
+    if (!selectedCapabilitySet) return;
+
     const capabilitySetsCap = selectedCapabilitySet.capabilities.reduce((obj, item) => {
       obj[item] = event.target.checked;
       return obj;

--- a/src/settings/components/CreateEditRole/CreateRole.js
+++ b/src/settings/components/CreateEditRole/CreateRole.js
@@ -22,7 +22,7 @@ const CreateRole = () => {
     disabledCapabilities,
     setDisabledCapabilities,
     capabilitySets,
-    capabilitySetsList } = useApplicationCapabilities();
+    capabilitySetsList, roleCapabilitySetsListIds } = useApplicationCapabilities();
 
   const onChangeCapabilityCheckbox = (event, id) => setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: event.target.checked });
   const onChangeCapabilitySetCheckbox = (event, capabilitySetId) => {
@@ -41,7 +41,7 @@ const CreateRole = () => {
   const isCapabilitySetSelected = id => !!selectedCapabilitySetsMap[id];
   const isCapabilityDisabled = id => !!disabledCapabilities[id];
 
-  const { mutateRole, isLoading } = useCreateRoleMutation(roleCapabilitiesListIds);
+  const { mutateRole, isLoading } = useCreateRoleMutation(roleCapabilitiesListIds, roleCapabilitySetsListIds);
 
   const goBack = () => history.push(pathname);
 

--- a/src/settings/components/CreateEditRole/CreateRole.test.js
+++ b/src/settings/components/CreateEditRole/CreateRole.test.js
@@ -36,13 +36,14 @@ const renderComponent = () => render(renderWithRouter(<CreateRole />));
 
 describe('CreateRole component', () => {
   const mockMutateRole = jest.fn();
+
   afterEach(() => {
     cleanup();
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
     cleanup();
+    jest.clearAllMocks();
   });
 
   beforeEach(() => {
@@ -50,9 +51,13 @@ describe('CreateRole component', () => {
     useApplicationCapabilities.mockReturnValue({ capabilities: { data:[{ id:'6e59c367-888a-4561-a3f3-3ca677de437f',
       applicationId:'app-platform-complete-0.0.5',
       resource:'Erm Agreements Collection',
-      actions:{ view:'6e59c367-888a-4561-a3f3-3ca677de437f' } }],
+      actions:{ view:'6e59c367-888a-4561-a3f3-3ca677de437f' } },
+    ],
     procedural:[],
-    settings:[] },
+    settings:[{ id:'DDD-888a-4561-a3f3-3ca677de437f',
+      applicationId:'app-platform-complete-0.0.5',
+      resource:'Erm Agreements Collection',
+      actions:{ view:'DDD-888a-4561-a3f3-3ca677de437f' } }] },
     checkedAppIdsMap: { 'app-platform-complete-0.0.5': true },
     roleCapabilitiesListIds: ['5c5198f9-de27-4349-9537-dc0b2b41c8c3'],
     capabilitySets: { data: [{ id:'d2e91897-c10d-46f6-92df-dad77c1e8862',
@@ -116,10 +121,10 @@ describe('CreateRole component', () => {
     expect(mockMutateRole).toHaveBeenCalledWith({ name: 'New Role', description: '' });
   });
 
-  it('test checkbox states', async () => {
+  it('should call capability sets handler actions on click', async () => {
     const { getAllByRole } = renderComponent();
 
-    expect(getAllByRole('checkbox')).toHaveLength(2);
+    expect(getAllByRole('checkbox')).toHaveLength(3);
 
     await userEvent.click(getAllByRole('checkbox')[0]);
 
@@ -127,5 +132,16 @@ describe('CreateRole component', () => {
       expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ '6e59c367-888a-4561-a3f3-3ca677de437f': true });
       expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('should call capability checkbox handler actions on click', async () => {
+    const { getAllByRole } = renderComponent();
+
+    await waitFor(() => {
+      expect(getAllByRole('checkbox')).toHaveLength(3);
+    });
+
+    await userEvent.click(getAllByRole('checkbox')[2]);
+    expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ 'DDD-888a-4561-a3f3-3ca677de437f': true });
   });
 });

--- a/src/settings/components/CreateEditRole/CreateRole.test.js
+++ b/src/settings/components/CreateEditRole/CreateRole.test.js
@@ -3,16 +3,16 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 
-import { render } from '@folio/jest-config-stripes/testing-library/react';
+import { render, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 
 
 import '@testing-library/jest-dom';
 
 import CreateRole from './CreateRole';
-import useCapabilities from '../../../hooks/useCapabilities';
 
 import useCreateRoleMutation from '../../../hooks/useCreateRoleMutation';
 import renderWithRouter from '../../../../test/jest/helpers/renderWithRouter';
+import useApplicationCapabilities from '../../../hooks/useApplicationCapabilities';
 
 
 jest.mock('../../../hooks/useCapabilities');
@@ -20,6 +20,7 @@ jest.mock('../../../hooks/useCreateRoleMutation', () => ({
   __esModule: true,
   default: jest.fn()
 }));
+jest.mock('../../../hooks/useApplicationCapabilities');
 
 jest.mock('@folio/stripes/components', () => {
   const original = jest.requireActual('@folio/stripes/components');
@@ -28,6 +29,8 @@ jest.mock('@folio/stripes/components', () => {
     Layer: jest.fn(({ children }) => <div data-testid="mock-layer">{children}</div>)
   };
 });
+const mockOnInitialLoad = jest.fn();
+const mockSetSelectedCapabilitiesMap = jest.fn();
 
 const renderComponent = () => render(renderWithRouter(<CreateRole />));
 
@@ -39,24 +42,44 @@ describe('CreateRole component', () => {
 
   afterAll(() => {
     jest.clearAllMocks();
+    cleanup();
   });
 
   beforeEach(() => {
     useCreateRoleMutation.mockReturnValue({ mutateRole:mockMutateRole, isLoading: false });
-    useCapabilities.mockReturnValue({ groupedCapabilitiesByType: { settings: [
-      {
-        id: '8d2da27c-1d56-48b6-9534218d-2bfae6d79dc8',
-        applicationId: 'Inventory-2.0',
-        name: 'foo_item.delete',
-        description: 'Settings: Delete foo item',
-        resource: 'Settings source',
-        action: 'edit',
-        type: 'settings',
-        permissions: ['foo.item.post'],
-        actions: { view: 'foo.item.get', edit: 'foo.item.put', manage: 'foo.item.post' },
-      },
+    useApplicationCapabilities.mockReturnValue({ capabilities: { data:[{ id:'6e59c367-888a-4561-a3f3-3ca677de437f',
+      applicationId:'app-platform-complete-0.0.5',
+      resource:'Erm Agreements Collection',
+      actions:{ view:'6e59c367-888a-4561-a3f3-3ca677de437f' } }],
+    procedural:[],
+    settings:[] },
+    checkedAppIdsMap: { 'app-platform-complete-0.0.5': true },
+    roleCapabilitiesListIds: ['5c5198f9-de27-4349-9537-dc0b2b41c8c3'],
+    capabilitySets: { data: [{ id:'d2e91897-c10d-46f6-92df-dad77c1e8862',
+      applicationId:'app-platform-complete-0.0.5',
+      resource:'Erm Agreements Collection',
+      actions:{ view:'d2e91897-c10d-46f6-92df-dad77c1e8862' },
+      capabilities:['6de59c367-888a-4561-a3f3-3ca677de437f'] }
     ] },
-    isSuccess: true });
+    capabilitySetsList:[{
+      id: 'd2e91897-c10d-46f6-92df-dad77c1e8862',
+      name: 'foo_item.create',
+      description: 'Sample: Create foo item',
+      resource: 'Erm Agreements Collection',
+      action: 'view',
+      type: 'data',
+      applicationId: 'app-platform-complete-0.0.5',
+      capabilities: ['6e59c367-888a-4561-a3f3-3ca677de437f'],
+    }],
+    selectedCapabilitiesMap: { },
+    roleCapabilitySetsListIds: [],
+    disabledCapabilities: {},
+    selectedCapabilitySetsMap: {},
+    onSubmitSelectApplications: jest.fn(),
+    setSelectedCapabilitiesMap:mockSetSelectedCapabilitiesMap,
+    onInitialLoad: mockOnInitialLoad,
+    setSelectedCapabilitySetsMap: jest.fn(),
+    setDisabledCapabilities: jest.fn() });
   });
 
   it('renders TextField and Button components', async () => {
@@ -91,5 +114,18 @@ describe('CreateRole component', () => {
     await userEvent.click(submitButton);
 
     expect(mockMutateRole).toHaveBeenCalledWith({ name: 'New Role', description: '' });
+  });
+
+  it('test checkbox states', async () => {
+    const { getAllByRole } = renderComponent();
+
+    expect(getAllByRole('checkbox')).toHaveLength(2);
+
+    await userEvent.click(getAllByRole('checkbox')[0]);
+
+    await waitFor(() => {
+      expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ '6e59c367-888a-4561-a3f3-3ca677de437f': true });
+      expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -36,9 +36,12 @@ const EditRole = ({ roleId }) => {
     selectedCapabilitySetsMap,
     setSelectedCapabilitySetsMap,
     disabledCapabilities,
-    setDisabledCapabilities, capabilitySets } = useApplicationCapabilities();
+    setDisabledCapabilities,
+    capabilitySets,
+    roleCapabilitySetsListIds } = useApplicationCapabilities();
 
   const shouldUpdateCapabilities = !isEqual(initialRoleCapabilitiesSelectedMap, selectedCapabilitiesMap);
+  const shouldUpdateCapabilitySets = !isEqual(initialRoleCapabilitySetsSelectedMap, selectedCapabilitiesMap);
 
   const onChangeCapabilityCheckbox = (event, id) => {
     setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: event.target.checked });
@@ -70,7 +73,7 @@ const EditRole = ({ roleId }) => {
 
   const goBack = () => history.push(pathname);
 
-  const { mutateRole, isLoading } = useEditRoleMutation({ id: roleId, name: roleName, description }, roleCapabilitiesListIds, shouldUpdateCapabilities);
+  const { mutateRole, isLoading } = useEditRoleMutation({ id: roleId, name: roleName, description }, { roleCapabilitiesListIds, shouldUpdateCapabilities, roleCapabilitySetsListIds, shouldUpdateCapabilitySets });
 
   const onSubmit = async (event) => {
     event.preventDefault();

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory, useLocation } from 'react-router';
-import { isEqual, isEmpty } from 'lodash';
+import { isEqual } from 'lodash';
 
 import CreateEditRoleForm from './CreateEditRoleForm';
 import useCapabilities from '../../../hooks/useCapabilities';
@@ -9,6 +9,8 @@ import useRoleCapabilities from '../../../hooks/useRoleCapabilities';
 import useEditRoleMutation from '../../../hooks/useEditRoleMutation';
 import useRoleById from '../../../hooks/useRoleById';
 import useApplicationCapabilities from '../../../hooks/useApplicationCapabilities';
+import useRoleCapabilitySets from '../../../hooks/useRoleCapabilitySets';
+import useCapabilitySets from '../../../hooks/useCapabilitySets';
 
 const EditRole = ({ roleId }) => {
   const history = useHistory();
@@ -19,12 +21,22 @@ const EditRole = ({ roleId }) => {
   const [description, setDescription] = useState('');
 
   const { capabilitiesList, isSuccess: isCapabilitiesLoaded } = useCapabilities();
-  const { initialRoleCapabilitiesSelectedMap } = useRoleCapabilities(roleId);
+  const { data: capabilitySetsData, isSuccess: isCapabilitySetsLoaded } = useCapabilitySets();
+  const { initialRoleCapabilitiesSelectedMap, isSuccess: isInitialRoleCapabilitiesLoaded } = useRoleCapabilities(roleId);
+
+  const { initialRoleCapabilitySetsSelectedMap,
+    capabilitySetsCapabilities, isSuccess: isRoleCapabilitySetsLoaded } = useRoleCapabilitySets(roleId);
+
   const { checkedAppIdsMap,
     onSubmitSelectApplications,
     capabilities,
     selectedCapabilitiesMap,
-    setSelectedCapabilitiesMap, roleCapabilitiesListIds, onInitialLoad } = useApplicationCapabilities();
+    setSelectedCapabilitiesMap, roleCapabilitiesListIds,
+    onInitialLoad,
+    selectedCapabilitySetsMap,
+    setSelectedCapabilitySetsMap,
+    disabledCapabilities,
+    setDisabledCapabilities, capabilitySets } = useApplicationCapabilities();
 
   const shouldUpdateCapabilities = !isEqual(initialRoleCapabilitiesSelectedMap, selectedCapabilitiesMap);
 
@@ -32,7 +44,22 @@ const EditRole = ({ roleId }) => {
     setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: event.target.checked });
   };
 
+  const onChangeCapabilitySetCheckbox = (event, capabilitySetId) => {
+    const selectedCapabilitySet = capabilitySetsData.capabilitySets.find(cap => cap.id === capabilitySetId);
+
+    const capabilitySetsCap = selectedCapabilitySet.capabilities.reduce((obj, item) => {
+      obj[item] = event.target.checked;
+      return obj;
+    }, {});
+
+    setDisabledCapabilities({ ...disabledCapabilities, ...capabilitySetsCap });
+    setSelectedCapabilitySetsMap({ ...selectedCapabilitySetsMap, [capabilitySetId]: event.target.checked });
+    setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, ...capabilitySetsCap });
+  };
+
   const isCapabilitySelected = (id) => !!selectedCapabilitiesMap[id];
+  const isCapabilitySetSelected = id => !!selectedCapabilitySetsMap[id];
+  const isCapabilityDisabled = id => !!disabledCapabilities[id];
 
   useEffect(() => {
     if (isRoleDetailsLoaded && roleDetails) {
@@ -52,7 +79,7 @@ const EditRole = ({ roleId }) => {
   };
 
   useEffect(() => {
-    if (!isEmpty(initialRoleCapabilitiesSelectedMap) && isCapabilitiesLoaded) {
+    if (isCapabilitiesLoaded && isRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded && isCapabilitySetsLoaded) {
       const appIds = capabilitiesList.filter(cap => Object.keys(initialRoleCapabilitiesSelectedMap).includes(cap.id))
         .reduce((acc, cap) => {
           if (!(cap.applicationId in acc)) {
@@ -61,27 +88,32 @@ const EditRole = ({ roleId }) => {
           return acc;
         }, {});
       onInitialLoad(appIds);
-      setSelectedCapabilitiesMap(initialRoleCapabilitiesSelectedMap);
+      setSelectedCapabilitiesMap({ ...initialRoleCapabilitiesSelectedMap, ...capabilitySetsCapabilities });
+      setSelectedCapabilitySetsMap({ ...initialRoleCapabilitySetsSelectedMap });
+      setDisabledCapabilities({ ...capabilitySetsCapabilities });
     }
-
     /* initialRoleCapabilitiesSelectedMap and isCapabilitiesLoaded is enough to know if initialCapabilitiesSelectedMap fetched and can be settled safely to local state */
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialRoleCapabilitiesSelectedMap, isCapabilitiesLoaded]);
+  }, [isCapabilitiesLoaded, isRoleCapabilitySetsLoaded, isCapabilitySetsLoaded]);
 
   return <CreateEditRoleForm
     title="ui-authorization-roles.crud.editRole"
     roleName={roleName}
     description={description}
     capabilities={capabilities}
-    isCapabilitySelected={isCapabilitySelected}
+    capabilitySets={capabilitySets}
+    checkedAppIdsMap={checkedAppIdsMap}
     isLoading={isLoading}
+    isCapabilitySelected={isCapabilitySelected}
+    isCapabilityDisabled={isCapabilityDisabled}
+    isCapabilitySetSelected={isCapabilitySetSelected}
     setRoleName={setRoleName}
     setDescription={setDescription}
     onSubmit={onSubmit}
     onClose={goBack}
     onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
+    onChangeCapabilitySetCheckbox={onChangeCapabilitySetCheckbox}
     onSaveSelectedApplications={onSubmitSelectApplications}
-    checkedAppIdsMap={checkedAppIdsMap}
   />;
 };
 

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -49,6 +49,7 @@ const EditRole = ({ roleId }) => {
 
   const onChangeCapabilitySetCheckbox = (event, capabilitySetId) => {
     const selectedCapabilitySet = capabilitySetsData.capabilitySets.find(cap => cap.id === capabilitySetId);
+    if (!selectedCapabilitySet) return;
 
     const capabilitySetsCap = selectedCapabilitySet.capabilities.reduce((obj, item) => {
       obj[item] = event.target.checked;

--- a/src/settings/components/CreateEditRole/EditRole.test.js
+++ b/src/settings/components/CreateEditRole/EditRole.test.js
@@ -10,6 +10,8 @@ import EditRole from './EditRole';
 import useCapabilities from '../../../hooks/useCapabilities';
 import useRoleCapabilities from '../../../hooks/useRoleCapabilities';
 import useEditRoleMutation from '../../../hooks/useEditRoleMutation';
+import useRoleCapabilitySets from '../../../hooks/useRoleCapabilitySets';
+import useCapabilitySets from '../../../hooks/useCapabilitySets';
 import useRoleById from '../../../hooks/useRoleById';
 import renderWithRouter from '../../../../test/jest/helpers/renderWithRouter';
 
@@ -19,6 +21,8 @@ const mockPostRequest = jest.fn().mockReturnValue({ ok:true });
 jest.mock('../../../hooks/useCapabilities');
 jest.mock('../../../hooks/useRoleCapabilities');
 jest.mock('../../../hooks/useRoleById');
+jest.mock('../../../hooks/useRoleCapabilitySets');
+jest.mock('../../../hooks/useCapabilitySets');
 
 jest.mock('../../../hooks/useEditRoleMutation', () => ({
   __esModule: true,
@@ -86,6 +90,8 @@ describe('EditRole component', () => {
     isSuccess: true });
     useRoleCapabilities.mockReturnValue({ initialRoleCapabilitiesSelectedMap: { '8d2da27c-1d56-48b6-9534218d-2bfae6d79dc8': true, 'ddsfffc-gff-dsgf-9534218d-fdgfdgfdgdfgdfg': true }, isSuccess: true });
     useRoleById.mockReturnValue({ roleDetails: { id: '1', name: 'Admin', description: 'Description' }, isSuccess: true });
+    useRoleCapabilitySets.mockReturnValue({ initialRoleCapabilitySetsSelectedMap: {}, isSuccess: true });
+    useCapabilitySets.mockReturnValue({ data: [], isSuccess: true });
   });
 
   it('renders TextField and Button components', async () => {

--- a/src/settings/components/CreateEditRole/EditRole.test.js
+++ b/src/settings/components/CreateEditRole/EditRole.test.js
@@ -75,15 +75,16 @@ describe('EditRole component', () => {
   });
 
   afterAll(() => {
+    cleanup();
     jest.clearAllMocks();
   });
 
-  beforeAll(() => {
+  beforeEach(() => {
     useEditRoleMutation.mockReturnValue({ mutateRole: mockMutateRole, isLoading: false });
     useCapabilities.mockReturnValue({ capabilitiesList: [
       {
-        id: '8d2da27c-1d56-48b6-9534218d-2bfae6d79dc8',
-        applicationId: 'Inventory-2.0',
+        id: '6e59c367-888a-4561-a3f3-3ca677de437f',
+        applicationId: 'app-platform-complete-0.0.5',
         name: 'foo_item.delete',
         description: 'Settings: Delete foo item',
         resource: 'Settings source',
@@ -211,7 +212,7 @@ describe('EditRole component', () => {
     expect(getByTestId('pluggable-select-application')).toBeInTheDocument();
   });
 
-  it('should call actions on select capabilities', async () => {
+  it('should call capabilities checkbox handlers', async () => {
     const { getAllByRole } = render(renderWithRouter(
       <EditRole roleId="1" />
     ));
@@ -223,5 +224,12 @@ describe('EditRole component', () => {
 
     await userEvent.click(getAllByRole('checkbox')[0]);
     expect(mockSetSelectedCapabilitiesMap).toHaveBeenCalledWith({ '6e59c367-888a-4561-a3f3-3ca677de437f': true });
+  });
+
+  it('should call initial load function from useApplicationCapabilities hook', async () => {
+    render(renderWithRouter(
+      <EditRole roleId="1" />
+    ));
+    expect(mockOnInitialLoad).toHaveBeenCalledWith({ 'app-platform-complete-0.0.5': true });
   });
 });

--- a/src/settings/utils/grouping.js
+++ b/src/settings/utils/grouping.js
@@ -103,13 +103,19 @@ const groupCapabilitiesObjectByTypeAndResource = (groupedTypeByResource) => {
       // Push to result[type] only single row with appropriate application and resource;
       // example of pushed value - {applicationId: 111, resource: "resource 1", action: {view: "222", edit: "333", manage: "444"}}
       Object.entries(capabilitiesByApplication).forEach(([application, resourceCapabilities]) => {
-        result[type].push({ id: resourceCapabilities[0].id,
+        const resultItem = { id: resourceCapabilities[0].id,
           applicationId: application,
           resource,
           actions: resourceCapabilities.reduce((acc, item) => {
             acc[item.action] = item.id;
             return acc;
-          }, {}) });
+          }, {}) };
+
+        // capabilities field exist only on capabilitySets entity. If exists flat them into single array
+        if (resourceCapabilities[0].capabilities) {
+          resultItem.capabilities = resourceCapabilities?.flatMap(caps => caps.capabilities);
+        }
+        result[type].push(resultItem);
       });
     });
   });


### PR DESCRIPTION
Fetching capability sets, and interacting with them on create and edit role modal. [Ref UIROLES-40](https://folio-org.atlassian.net/browse/UIROLES-40).
Key points of introducing functionality:
1. Capability set entity has almost the same structure with capability, except that capability set has capabilities field, that container ids of capabilities included in the current set;
2. Capabilities that included in capability set should be disabled;
3. On select capability sets, capabilities listed in the set should be checked, and vice versa. 