### PR TITLE
Fix error when updating only name/description for authorization role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Show spinner while loading capabilities/capabilitySets tables. Refs UIROLES-42
 * Show capabilities/capability sets depending on selected applications. Refs UIROLES-40.
 * Include `settings.authorization-roles.enabled` permission set. Refs UIROLES-54.
+* Fix error when updating only name/description for authorization role. Refs UIROLES-62.
 
 ## 1.2.0
 

--- a/src/hooks/useCreateRoleMutation.js
+++ b/src/hooks/useCreateRoleMutation.js
@@ -10,10 +10,10 @@ const useCreateRoleMutation = (roleCapabilitiesListIds, capabilitySetListIds) =>
     onSuccess: async (newRole) => {
       await queryClient.invalidateQueries(namespace);
       if (roleCapabilitiesListIds.length > 0) {
-        await ky.post('roles/capabilities', { json: { roleId:newRole.id, capabilityIds: roleCapabilitiesListIds } }).json();
+        await ky.post('roles/capabilities', { json: { roleId: newRole.id, capabilityIds: roleCapabilitiesListIds } }).json();
       }
       if (capabilitySetListIds.length > 0) {
-        await ky.post('roles/capability-sets', { json: { roleId:newRole.id, capabilitySetIds: capabilitySetListIds } }).json();
+        await ky.post('roles/capability-sets', { json: { roleId: newRole.id, capabilitySetIds: capabilitySetListIds } }).json();
       }
     },
     onError:(error) => window.alert(JSON.stringify(error)) // eslint-disable-line no-alert

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -42,7 +42,7 @@ const EditRole = ({ roleId }) => {
     isInitialLoaded } = useApplicationCapabilities();
 
   const shouldUpdateCapabilities = !isEqual(initialRoleCapabilitiesSelectedMap, selectedCapabilitiesMap);
-  const shouldUpdateCapabilitySets = !isEqual(initialRoleCapabilitySetsSelectedMap, selectedCapabilitiesMap);
+  const shouldUpdateCapabilitySets = !isEqual(initialRoleCapabilitySetsSelectedMap, selectedCapabilitySetsMap);
 
   const onChangeCapabilityCheckbox = (event, id) => {
     setSelectedCapabilitiesMap({ ...selectedCapabilitiesMap, [id]: event.target.checked });


### PR DESCRIPTION
- Fixes [UIROLES-62](https://folio-org.atlassian.net/browse/UIROLES-62).
- Wrong variable was used before making object comparison incorrectly detect difference in capability sets.
- Lint fix.