### PR TITLE
UIROLES-70 Add secondary sort for Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Server-side query sort (temporary, lacking i18n).
 * Clean up `package.json` cruft etc. Refs UIROLES-57.
 * Correctly assign/unassign users to roles. Refs UIROLES-63, UIROLES-43.
+* Fix capabilities/sets not sorted by "Resource" value when creating/editing an authorization role. Refs UIROLES-70.
 
 ## [1.3.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.3.0) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.2.0...v1.3.0)

--- a/src/settings/utils/grouping.js
+++ b/src/settings/utils/grouping.js
@@ -122,7 +122,8 @@ const groupCapabilitiesObjectByTypeAndResource = (groupedTypeByResource) => {
 
   for (const key in result) {
     if (key in result) {
-      result[key].sort((a, b) => a.applicationId.localeCompare(b.applicationId));
+      // first sort by Application ID, then sort by Resource
+      result[key].sort((a, b) => (a.applicationId.localeCompare(b.applicationId) || a.resource.localeCompare(b.resource)));
     }
   }
 

--- a/src/settings/utils/grouping.test.js
+++ b/src/settings/utils/grouping.test.js
@@ -48,9 +48,9 @@ describe('Test grouping functions', () => {
         { id: 22, applicationId: 'ccc', resource: 'resource1', actions: { manage: 22, delete: 222 } },
       ],
       settings: [{ id: 5, applicationId: 'app1', resource: 'resource2', actions: { edit: 5, delete: 6 } }],
-      procedural: [
-        { id: 7, applicationId: 'app1', resource: 'resource3', actions: { execute: 7 } },
+      procedural: [ // expecting list first sorted by applicationId, then by resource
         { id: 8, applicationId: 'app1', resource: 'resource1', actions: { execute: 8 } },
+        { id: 7, applicationId: 'app1', resource: 'resource3', actions: { execute: 7 } },
         { id: 9, applicationId: 'bbb', resource: 'resource3', actions: { execute: 9, delete: 10 } },
       ]
     };


### PR DESCRIPTION
- Fixes [UIROLES-70](https://folio-org.atlassian.net/browse/UIROLES-70)
- Results now sort first by `Application ID` and then by `Resource` which is more natural for a user to browse through

<img width="1633" alt="image" src="https://github.com/folio-org/ui-authorization-roles/assets/28395235/c6bb34b8-086a-47d2-86f8-046160add46c">

<img width="1633" alt="image" src="https://github.com/folio-org/ui-authorization-roles/assets/28395235/c59f690c-5633-4fce-b1ef-6e4cb5d6730b">
