### PR TITLE
UIROLES-52 Map object to prevent it from overwriting itself on multiple renders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Clean up `package.json` cruft etc. Refs UIROLES-57.
 * Correctly assign/unassign users to roles. Refs UIROLES-63, UIROLES-43.
 * Fix capabilities/sets not sorted by "Resource" value when creating/editing an authorization role. Refs UIROLES-70.
+* Fix Patron group not always shown for assigned users in detailed view of authorization role. Refs UIROLES-52.
 
 ## [1.3.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.3.0) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.2.0...v1.3.0)

--- a/src/settings/components/RoleDetails/AccordionUsers.js
+++ b/src/settings/components/RoleDetails/AccordionUsers.js
@@ -31,13 +31,19 @@ const AccordionUsers = ({ roleId }) => {
     return getFullName(a).localeCompare(getFullName(b));
   });
 
-  users.forEach(i => {
-    i.fullName = (
+  const usersData = users.map(i => {
+    const fullName = (
       <TextLink to={`/users/preview/${i.id}?query=${i.username}`}>
         {getFullName(i)}
       </TextLink>
     );
-    i.patronGroup = groupHash[i.patronGroup]?.desc || <NoValue />;
+
+    const patronGroup = groupHash[i.patronGroup]?.group || <NoValue />;
+
+    return {
+      fullName,
+      patronGroup
+    };
   });
 
   return (
@@ -47,11 +53,11 @@ const AccordionUsers = ({ roleId }) => {
       }
       displayWhenClosed={
         <Badge>
-          {users?.length || 0}
+          {usersData?.length || 0}
         </Badge>
       }
       displayWhenOpen={<AssignUsers
-        selectedUsers={users}
+        selectedUsers={usersData}
         roleId={roleId}
         refetch={refetch}
       />}
@@ -61,7 +67,7 @@ const AccordionUsers = ({ roleId }) => {
           fullName: <FormattedMessage id="ui-authorization-roles.role-details.accordion-users.columns.fullName" />,
           patronGroup: <FormattedMessage id="ui-authorization-roles.role-details.accordion-users.columns.patronGroup" />,
         }}
-        contentData={users}
+        contentData={usersData}
         visibleColumns={['fullName', 'patronGroup']}
       />
     </Accordion>

--- a/src/settings/components/RoleDetails/AccordionUsers.test.js
+++ b/src/settings/components/RoleDetails/AccordionUsers.test.js
@@ -71,8 +71,8 @@ describe('AccordionUsers component', () => {
       getByText('ui-authorization-roles.assignedUsers');
       getByText(users[0].personal.firstName, { exact: false });
       getByText(users[1].personal.firstName, { exact: false });
-      getByText(usergroups[0].desc, { exact: false });
-      getByText(usergroups[1].desc, { exact: false });
+      getByText(usergroups[0].group, { exact: false });
+      getByText(usergroups[1].group, { exact: false });
     });
   });
 


### PR DESCRIPTION
- Fixes [UIROLES-52](https://folio-org.atlassian.net/browse/UIROLES-52)
- Use correct property `.group` instead of `.desc` to match usage in selection modal (see: https://github.com/folio-org/ui-plugin-find-user/blob/b6031584d7c32c2e75d0f170735f5073a2e43e54/src/UserSearchView.js#L255).