### PR TITLE
UIROLES-41 use NoValue for unselected capabilities in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Correctly assign/unassign users to roles. Refs UIROLES-63, UIROLES-43.
 * Fix capabilities/sets not sorted by "Resource" value when creating/editing an authorization role. Refs UIROLES-70.
 * Fix Patron group not always shown for assigned users in detailed view of authorization role. Refs UIROLES-52.
+* Use `<NoValue>` to represent unselected checkboxes in read-only mode. Refs UIROLES-41.
 
 ## [1.3.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.3.0) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.2.0...v1.3.0)

--- a/src/settings/components/Capabilities/ItemActionCheckbox.js
+++ b/src/settings/components/Capabilities/ItemActionCheckbox.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import {
+  NoValue
+} from '@folio/stripes/components';
+
 import { CheckboxWithAsterisk } from '../../../components/CheckboxWithAsterisk/CheckboxWithAsterisk';
 import { useCheckboxAriaStates } from './helpers';
 
@@ -12,8 +17,13 @@ const ItemActionCheckbox = ({
   isCapabilityDisabled
 }) => {
   const { getCheckboxAriaLabel } = useCheckboxAriaStates();
+  const checked = isCapabilitySelected(item.actions[action]);
 
   if (!readOnly && !item.actions[action]) return null;
+
+  if (readOnly && !checked) {
+    return <NoValue />;
+  }
 
   return <CheckboxWithAsterisk
     aria-describedby="asterisk-policy-desc"


### PR DESCRIPTION
Use `<NoValue />` in place of unselected checkboxes in order to provide something more visually distinct. When many checkboxes are present, it is difficult to distinguish selected from unselected checkboxes.

Refs [UIROLES-41](https://folio-org.atlassian.net/browse/UIROLES-41)