### PR TITLE
UIROLES-71 Show user name instead of UUID in Role Detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix capabilities/sets not sorted by "Resource" value when creating/editing an authorization role. Refs UIROLES-70.
 * Fix Patron group not always shown for assigned users in detailed view of authorization role. Refs UIROLES-52.
 * Use `<NoValue>` to represent unselected checkboxes in read-only mode. Refs UIROLES-41.
+* Show user name instead of UUID in Role Detail page. Refs UIROLES-71.
 
 ## [1.3.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.3.0) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.2.0...v1.3.0)

--- a/src/settings/components/RoleDetails/RoleDetails.js
+++ b/src/settings/components/RoleDetails/RoleDetails.js
@@ -17,6 +17,8 @@ import {
   NoValue,
   ConfirmationModal
 } from '@folio/stripes/components';
+import { UserName } from '@folio/stripes/smart-components';
+import { useStripes } from '@folio/stripes/core';
 
 import { useHistory, useLocation } from 'react-router';
 import css from '../../style.css';
@@ -27,6 +29,9 @@ import AccordionCapabilitySets from './AccordionCapabilitySets';
 import useDeleteRoleMutation from '../../../hooks/useDeleteRoleMutation';
 
 const RoleDetails = ({ onClose, roleId }) => {
+  const { connect } = useStripes();
+
+  const ConnectedUserName = connect(UserName);
   const history = useHistory();
   const { pathname } = useLocation();
 
@@ -77,9 +82,11 @@ const RoleDetails = ({ onClose, roleId }) => {
               createdDate={role?.metadata?.createdDate}
               lastUpdatedDate={role?.metadata?.modifiedDate}
               lastUpdatedBy={
-                role?.metadata?.modifiedBy || ''
+                <ConnectedUserName id={role?.metadata?.modifiedBy || ''} />
               }
-              createdBy={role?.metadata?.createdBy || ''}
+              createdBy={
+                <ConnectedUserName id={role?.metadata?.createdBy || ''} />
+              }
             />
             <KeyValue
               data-testid="role-name"


### PR DESCRIPTION
- Fixes [UIROLES-71](https://folio-org.atlassian.net/browse/UIROLES-71)
- Pull in `<ConnectedUserName>` to translate UUID to User Name.