### PR TITLE
UIROLES-60: handle loading state on submit select applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix Patron group not always shown for assigned users in detailed view of authorization role. Refs UIROLES-52.
 * Use `<NoValue>` to represent unselected checkboxes in read-only mode. Refs UIROLES-41.
 * Show user name instead of UUID in Role Detail page. Refs UIROLES-71.
+* Show spinner while loading capabilities/capabilitySets tables after selecting applications. Refs UIROLES-60.
 
 ## [1.3.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.3.0) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.2.0...v1.3.0)

--- a/src/hooks/useApplicationCapabilities.js
+++ b/src/hooks/useApplicationCapabilities.js
@@ -44,20 +44,26 @@ const useApplicationCapabilities = () => {
     return ky.get(`capability-sets?limit=${stripes.config.maxUnpagedResourceCount}&query=${queryByApplications}`).json();
   };
 
+  const cleanupCapabilitiesData = () => {
+    setCapabilities({ data: [], settings: [], procedural: [] });
+    setCapabilitySets({ data: [], settings: [], procedural: [] });
+    setSelectedCapabilitiesMap({});
+    setSelectedCapabilitySetsMap({});
+  };
+
   const onSubmitSelectApplications = async (appIds, onClose) => {
+    // cleanup is preventing users from interacting with data that might no longer be available after selection
+    cleanupCapabilitiesData();
+    onClose?.();
     setCheckedAppIdsMap(appIds);
     const listOfIds = Object.entries(appIds).filter(([, isSelected]) => isSelected).map(([id]) => id);
 
     if (isEmpty(listOfIds)) {
-      setCapabilities({ data: [], settings: [], procedural: [] });
-      setCapabilitySets({ data: [], settings: [], procedural: [] });
-      setSelectedCapabilitiesMap({});
-      setSelectedCapabilitySetsMap({});
-      onClose?.();
       return;
     }
 
     try {
+      setIsInitialLoaded(false);
       const capabilitiesData = await requestApplicationCapabilitiesList(listOfIds);
       const capabilitySetsData = await requestApplicationCapabilitySets(listOfIds);
 
@@ -69,7 +75,6 @@ const useApplicationCapabilities = () => {
       setSelectedCapabilitiesMap(updatedSelectedCapabilitiesMap);
       setSelectedCapabilitySetsMap(updatedSelectedCapabilitySetsMap);
       setIsInitialLoaded(true);
-      onClose?.();
     } catch (error) {
       console.error(error); // eslint-disable-line no-console
     }

--- a/src/hooks/useApplicationCapabilities.test.js
+++ b/src/hooks/useApplicationCapabilities.test.js
@@ -86,4 +86,27 @@ describe('useApplicationCapabilities', () => {
       expect(result.current.selectedCapabilitiesMap).toStrictEqual({});
     });
   });
+
+  it('should call initial load function', async () => {
+    const { result } = renderHook(useApplicationCapabilities);
+
+    const data = { capabilities: [{ id: 1, applicationId: 'cap1', type: 'data', action:'edit', resource: 'r1' }, { id: 12, applicationId: 'cap12', type: 'data', action: 'create', resource: 'r1' }] };
+
+    const mockGet = jest.fn(() => ({
+      json: () => Promise.resolve(data),
+    }));
+
+    useOkapiKy.mockClear().mockReturnValue({
+      get: mockGet,
+    });
+
+    const appIds = {};
+
+    await waitFor(async () => {
+      await result.current.onInitialLoad(appIds);
+
+      expect(result.current.capabilities).toStrictEqual({ data: [], settings: [], procedural: [] });
+      expect(result.current.selectedCapabilitiesMap).toStrictEqual({});
+    });
+  });
 });


### PR DESCRIPTION
**[UIROLES-60](https://folio-org.atlassian.net/browse/UIROLES-60) - Show spinner while loading capabilities/capabilitySets tables after selecting applications**

On `save and close` modal is immediately closed and loading spinners are shown on capabilities accordions.

<img width="1224" alt="Screenshot 2024-05-15 at 15 41 04" src="https://github.com/folio-org/ui-authorization-roles/assets/121284650/a9bf16af-7233-42a6-969a-d49bc11425ac">
<img width="1185" alt="Screenshot 2024-05-15 at 15 41 34" src="https://github.com/folio-org/ui-authorization-roles/assets/121284650/b29ff504-e9fa-4a94-8325-95f766040ba8">
