### PR TITLE
UIROLES-77 pass string to Layer

### DIFF
--- a/src/settings/components/CreateEditRole/CreateEditRoleForm.js
+++ b/src/settings/components/CreateEditRole/CreateEditRoleForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FormattedMessage } from 'react-intl';
+import { useIntl, FormattedMessage } from 'react-intl';
 import {
   Accordion,
   AccordionSet,
@@ -57,8 +57,10 @@ function CreateEditRoleForm({
     onClick={onSubmit}
   ><FormattedMessage id="ui-authorization-roles.crud.saveAndClose" /></Button>;
 
+  const intl = useIntl();
+
   return <form onSubmit={onSubmit} data-testid="create-role-form">
-    <Layer isOpen inRootSet contentLabel={<FormattedMessage id={title} />}>
+    <Layer isOpen inRootSet contentLabel={intl.formatMessage({ id: title })}>
       <Paneset isRoot>
         <Pane
           centerContent


### PR DESCRIPTION
`<Layer>` expects a string for its `contentLabel` prop. Give it one.

Refs [UIROLES-77](https://folio-org.atlassian.net/issues/UIROLES-77)