### PR TITLE
UIROLES-67 show capabilities inherited from capability-sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Show user name instead of UUID in Role Detail page. Refs UIROLES-71.
 * Show spinner while loading capabilities/capabilitySets tables after selecting applications. Refs UIROLES-60.
 * Show callout instead of JS alert on save/delete error. Refs UIROLES-53.
+* Role details should show capabilities inherited from capability-sets. Refs UIROLES-67.
 
 ## [1.3.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.3.0) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.2.0...v1.3.0)

--- a/src/hooks/useRoleCapabilities.js
+++ b/src/hooks/useRoleCapabilities.js
@@ -6,16 +6,27 @@ import { useNamespace, useOkapiKy } from '@folio/stripes/core';
 import { CAPABILITES_LIMIT } from './constants';
 import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
-const useRoleCapabilities = (roleId) => {
+const useRoleCapabilities = (roleId, expand = false) => {
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'role-capabilities-list' });
 
   const { data, isSuccess } = useQuery([namespace, roleId],
-    () => ky.get(`roles/${roleId}/capabilities?limit=${CAPABILITES_LIMIT}&query=cql.allRecords=1 sortby resource`).json(),
-    { enabled: !!roleId,
+    () => ky.get(
+      `roles/${roleId}/capabilities`,
+      {
+        searchParams: {
+          limit: CAPABILITES_LIMIT,
+          query: 'cql.allRecords=1 sortby resource',
+          expand: !!expand,
+        },
+      }
+    ).json(),
+    {
+      enabled: !!roleId,
       placeholderData: {
         capabilities: [], totalRecords: 0
-      } });
+      }
+    });
 
   const initialRoleCapabilitiesSelectedMap = useMemo(() => {
     return data?.capabilities.reduce((acc, capability) => {

--- a/src/settings/components/RoleDetails/AccordionCapabilities.js
+++ b/src/settings/components/RoleDetails/AccordionCapabilities.js
@@ -18,7 +18,7 @@ const AccordionCapabilities = ({ roleId }) => {
     initialRoleCapabilitiesSelectedMap,
     groupedRoleCapabilitiesByType,
     isSuccess
-  } = useRoleCapabilities(roleId);
+  } = useRoleCapabilities(roleId, true);
 
   if (!isSuccess) {
     return <Loading />;


### PR DESCRIPTION
The role-details pane should show all capabilities, both those directly assigned and those inherited from capability-sets. Retrieve them all by supplying the `expand=true` query-param to the
`/roles/{roleId}/capabilities` query.

Refs [UIROLES-67](https://folio-org.atlassian.net/browse/UIROLES-67)