### PR TITLE
UIROLES-78 avoid invalid queries for /users/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Show spinner while loading capabilities/capabilitySets tables after selecting applications. Refs UIROLES-60.
 * Show callout instead of JS alert on save/delete error. Refs UIROLES-53.
 * Role details should show capabilities inherited from capability-sets. Refs UIROLES-67.
+* Handle empty `metadata` values without invalid `/users/` API queries. Refs UIROLES-78.
 
 ## [1.3.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.3.0) (2024-03-05)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.2.0...v1.3.0)

--- a/src/settings/components/RoleDetails/RoleDetails.js
+++ b/src/settings/components/RoleDetails/RoleDetails.js
@@ -10,14 +10,13 @@ import {
   Pane,
   Button,
   KeyValue,
-  MetaSection,
   Icon,
   PaneHeader,
   Loading,
   NoValue,
   ConfirmationModal
 } from '@folio/stripes/components';
-import { UserName } from '@folio/stripes/smart-components';
+import { ViewMetaData } from '@folio/stripes/smart-components';
 import { useStripes } from '@folio/stripes/core';
 
 import { useHistory, useLocation } from 'react-router';
@@ -32,7 +31,8 @@ import useErrorCallout from '../../../hooks/useErrorCallout';
 const RoleDetails = ({ onClose, roleId }) => {
   const { connect } = useStripes();
 
-  const ConnectedUserName = connect(UserName);
+  const ConnectedViewMetaData = connect(ViewMetaData);
+
   const history = useHistory();
   const { pathname } = useLocation();
   const { sendErrorCallout } = useErrorCallout();
@@ -77,19 +77,7 @@ const RoleDetails = ({ onClose, roleId }) => {
               <FormattedMessage id="ui-authorization-roles.generalInformation" />
             }
           >
-            <MetaSection
-              id="roleMetadataId"
-              contentId="roleMetadata"
-              headingLevel={4}
-              createdDate={role?.metadata?.createdDate}
-              lastUpdatedDate={role?.metadata?.modifiedDate}
-              lastUpdatedBy={
-                <ConnectedUserName id={role?.metadata?.modifiedBy || ''} />
-              }
-              createdBy={
-                <ConnectedUserName id={role?.metadata?.createdBy || ''} />
-              }
-            />
+            <ConnectedViewMetaData metadata={role?.metadata} />
             <KeyValue
               data-testid="role-name"
               label={


### PR DESCRIPTION
Use `<ViewMetaData>` to handle display of the metadata accordion. It knows how to handle empty values and will avoid an extra query when the `createdBy` and `lastUpdatedBy` values match. `<UserName>` is not so clever and will issue a query even when it doesn't have an id.

Refs [UIROLES-78](https://folio-org.atlassian.net/browse/UIROLES-78)