### PR TITLE
UIROLES-73: assigned users are not checked when open Pluggable find-user component

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -18,7 +18,7 @@ jest.mock('./settings', () => ({
 
 describe('App component', () => {
   it('calls the addKey of useIntlKeyStore function with the correct namespace', () => {
-    render(<App />);
+    render(<App match={{ path: '/settings/auz-rolez' }} />);
     expect(useIntlKeyStore()).toHaveBeenCalledWith('ui-authorization-roles');
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,11 @@ const App = () => {
   const addKey = useIntlKeyStore((state) => state.addKey);
   addKey('ui-authorization-roles');
 
-  return <Router basename={baseUrl}>
+  return <Router>
     <Switch>
-      <Route exact path="/create" component={CreateRole} />
-      <Route exact path="/:id/edit" component={EditRole} />
-      <Route path="/:id" component={Settings} />
-      <Route path="/" component={Settings} />
+      <Route exact path={`${baseUrl}/create`} component={CreateRole} />
+      <Route exact path={`${baseUrl}/:id/edit`} component={EditRole} />
+      <Route path={`${baseUrl}/:id?`} component={Settings} />
     </Switch>
   </Router>;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,29 @@
 import React from 'react';
 import { useIntlKeyStore } from '@k-int/stripes-kint-components';
 import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 import Settings from './settings';
 import CreateRole from './settings/components/CreateEditRole/CreateRole';
 import EditRole from './settings/components/CreateEditRole/EditRole';
 
-const baseUrl = '/settings/authorization-roles';
-
-const App = () => {
+const App = ({ match: { path } }) => {
   const addKey = useIntlKeyStore((state) => state.addKey);
   addKey('ui-authorization-roles');
 
-  return <Router>
-    <Switch>
-      <Route exact path={`${baseUrl}/create`} component={CreateRole} />
-      <Route exact path={`${baseUrl}/:id/edit`} component={EditRole} />
-      <Route path={`${baseUrl}/:id?`} component={Settings} />
-    </Switch>
-  </Router>;
+  return (
+    <Router>
+      <Switch>
+        <Route exact path={`${path}/create`} render={() => <CreateRole path={path} />} />
+        <Route exact path={`${path}/:id/edit`} render={() => <EditRole path={path} />} />
+        <Route path={`${path}/:id?`} render={() => <Settings path={path} />} />
+      </Switch>
+    </Router>
+  );
+};
+
+App.propTypes = {
+  match: PropTypes.object.isRequired
 };
 
 export default App;

--- a/src/settings/components/CreateEditRole/CreateRole.js
+++ b/src/settings/components/CreateEditRole/CreateRole.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router';
+import PropTypes from 'prop-types';
 
 import CreateEditRoleForm from './CreateEditRoleForm';
 import useCreateRoleMutation from '../../../hooks/useCreateRoleMutation';
 import useApplicationCapabilities from '../../../hooks/useApplicationCapabilities';
 import useErrorCallout from '../../../hooks/useErrorCallout';
 
-const CreateRole = () => {
+const CreateRole = ({ path }) => {
   const history = useHistory();
 
   const [roleName, setRoleName] = useState('');
@@ -47,7 +48,7 @@ const CreateRole = () => {
 
   const { mutateRole, isLoading } = useCreateRoleMutation(roleCapabilitiesListIds, roleCapabilitySetsListIds, sendErrorCallout);
 
-  const onClose = () => history.push('/');
+  const onClose = () => history.push(path);
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -75,6 +76,10 @@ const CreateRole = () => {
     onSaveSelectedApplications={onSubmitSelectApplications}
     checkedAppIdsMap={checkedAppIdsMap}
   />;
+};
+
+CreateRole.propTypes = {
+  path: PropTypes.string.isRequired
 };
 
 export default CreateRole;

--- a/src/settings/components/CreateEditRole/CreateRole.js
+++ b/src/settings/components/CreateEditRole/CreateRole.js
@@ -47,12 +47,12 @@ const CreateRole = () => {
 
   const { mutateRole, isLoading } = useCreateRoleMutation(roleCapabilitiesListIds, roleCapabilitySetsListIds, sendErrorCallout);
 
-  const goBack = () => history.push('/');
+  const onClose = () => history.push('/');
 
   const onSubmit = async (e) => {
     e.preventDefault();
     await mutateRole({ name: roleName, description });
-    goBack();
+    onClose();
   };
 
   return <CreateEditRoleForm
@@ -68,7 +68,7 @@ const CreateRole = () => {
     setRoleName={setRoleName}
     setDescription={setDescription}
     onSubmit={onSubmit}
-    onClose={goBack}
+    onClose={onClose}
     onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
     onChangeCapabilitySetCheckbox={onChangeCapabilitySetCheckbox}
     selectedCapabilitiesMap={selectedCapabilitiesMap}

--- a/src/settings/components/CreateEditRole/CreateRole.test.js
+++ b/src/settings/components/CreateEditRole/CreateRole.test.js
@@ -25,7 +25,7 @@ jest.mock('@folio/stripes/components', () => {
 const mockOnInitialLoad = jest.fn();
 const mockSetSelectedCapabilitiesMap = jest.fn();
 
-const renderComponent = () => render(renderWithRouter(<CreateRole />));
+const renderComponent = () => render(renderWithRouter(<CreateRole path="/settings/auz-rolez" />));
 
 describe('CreateRole component', () => {
   const mockMutateRole = jest.fn();

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { useHistory, useRouteMatch } from 'react-router';
+import { useParams, useHistory } from 'react-router-dom';
 import { isEqual } from 'lodash';
+import PropTypes from 'prop-types';
 
 import CreateEditRoleForm from './CreateEditRoleForm';
 import useCapabilities from '../../../hooks/useCapabilities';
@@ -12,16 +13,11 @@ import useRoleCapabilitySets from '../../../hooks/useRoleCapabilitySets';
 import useCapabilitySets from '../../../hooks/useCapabilitySets';
 import useSendErrorCallout from '../../../hooks/useErrorCallout';
 
-const EditRole = () => {
+const EditRole = ({ path }) => {
   const history = useHistory();
-  const router = useRouteMatch();
-  const roleId = router.params.id;
-  const { roleDetails, isSuccess: isRoleDetailsLoaded } = useRoleById(roleId);
+  const { id: roleId } = useParams();
 
-  const getRowUrl = id => {
-    const basePath = router.path.split(':')[0];
-    return basePath.endsWith('/') ? `${basePath}${id}` : `${basePath}/${id}`;
-  };
+  const { roleDetails, isSuccess: isRoleDetailsLoaded } = useRoleById(roleId);
 
   const [roleName, setRoleName] = useState('');
   const [description, setDescription] = useState('');
@@ -81,7 +77,7 @@ const EditRole = () => {
     }
   }, [isRoleDetailsLoaded, roleDetails]);
 
-  const onClose = () => history.push(getRowUrl(roleId));
+  const onClose = () => history.push(`${path}/${roleId}`);
 
   const { mutateRole, isLoading } = useEditRoleMutation(
     { id: roleId, name: roleName, description },
@@ -134,6 +130,10 @@ const EditRole = () => {
     isCapabilitiesLoading={!isInitialLoaded}
     isCapabilitySetsLoading={!isInitialLoaded}
   />;
+};
+
+EditRole.propTypes = {
+  path: PropTypes.string.isRequired
 };
 
 export default EditRole;

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -18,6 +18,11 @@ const EditRole = () => {
   const roleId = router.params.id;
   const { roleDetails, isSuccess: isRoleDetailsLoaded } = useRoleById(roleId);
 
+  const getRowUrl = id => {
+    const basePath = router.path.split(':')[0];
+    return basePath.endsWith('/') ? `${basePath}${id}` : `${basePath}/${id}`;
+  };
+
   const [roleName, setRoleName] = useState('');
   const [description, setDescription] = useState('');
 
@@ -76,7 +81,7 @@ const EditRole = () => {
     }
   }, [isRoleDetailsLoaded, roleDetails]);
 
-  const goBack = () => history.push(`/${roleId}`);
+  const onClose = () => history.push(getRowUrl(roleId));
 
   const { mutateRole, isLoading } = useEditRoleMutation(
     { id: roleId, name: roleName, description },
@@ -87,7 +92,7 @@ const EditRole = () => {
   const onSubmit = async (event) => {
     event.preventDefault();
     await mutateRole();
-    goBack();
+    onClose();
   };
 
   useEffect(() => {
@@ -122,7 +127,7 @@ const EditRole = () => {
     setRoleName={setRoleName}
     setDescription={setDescription}
     onSubmit={onSubmit}
-    onClose={goBack}
+    onClose={onClose}
     onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
     onChangeCapabilitySetCheckbox={onChangeCapabilitySetCheckbox}
     onSaveSelectedApplications={onSubmitSelectApplications}

--- a/src/settings/components/CreateEditRole/EditRole.test.js
+++ b/src/settings/components/CreateEditRole/EditRole.test.js
@@ -33,7 +33,13 @@ jest.mock('../../../hooks/useEditRoleMutation', () => ({
 const mockMutateFn = jest.fn();
 jest.mock('react-query', () => ({
   ...jest.requireActual('react-query'),
-  useMutation: () => ({ mutate: mockMutateFn, isLoading: false }),
+  useMutation: jest.fn(() => ({ mutate: mockMutateFn, isLoading: false })),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn().mockReturnValue({ id: 1 }),
+  useHistory: jest.fn(() => ({ push: jest.fn() })),
 }));
 
 const mockPluggableOnClose = jest.fn();
@@ -146,7 +152,7 @@ describe('EditRole component', () => {
 
   it('renders TextField and Button components', async () => {
     const { getByTestId } = render(renderWithRouter(
-      <EditRole roleId="1" />
+      <EditRole path="/auz/roles/1" />
     ));
 
     expect(getByTestId('create-role-form')).toBeInTheDocument();
@@ -154,7 +160,7 @@ describe('EditRole component', () => {
 
   it('changes name, description input values', async () => {
     const { getByTestId } = render(renderWithRouter(
-      <EditRole roleId="1" />
+      <EditRole path="/auz/roles/1" />
     ));
 
     const nameInput = getByTestId('rolename-input');
@@ -171,7 +177,7 @@ describe('EditRole component', () => {
 
   it('actions on click footer buttons', async () => {
     const { getByTestId, getByRole } = render(renderWithRouter(
-      <EditRole roleId="1" />
+      <EditRole path="/auz/roles/1" />
     ));
 
     const submitButton = getByRole('button', { name: 'ui-authorization-roles.crud.saveAndClose' });
@@ -188,7 +194,7 @@ describe('EditRole component', () => {
 
   it('onSubmit invalidates "ui-authorization-roles" query and calls goBack on success', async () => {
     const { getByRole, getByTestId } = render(renderWithRouter(
-      <EditRole roleId="1" />
+      <EditRole path="/auz/roles/1" />
     ));
     const submitButton = getByRole('button', { name: 'ui-authorization-roles.crud.saveAndClose' });
 
@@ -203,7 +209,7 @@ describe('EditRole component', () => {
 
   it('should set role name and description when selectedRole is truthy', () => {
     const { getByTestId } = render(renderWithRouter(
-      <EditRole roleId="1" />
+      <EditRole path="/auz/roles/1" />
     ));
 
     const roleNameInput = getByTestId('rolename-input');
@@ -216,7 +222,7 @@ describe('EditRole component', () => {
 
   it('should call capabilities checkbox handlers', async () => {
     const { getAllByRole } = render(renderWithRouter(
-      <EditRole roleId="1" />
+      <EditRole path="/auz/roles/1" />
     ));
 
     const capabilitiesCheckboxLength = 3;
@@ -233,7 +239,7 @@ describe('EditRole component', () => {
 
   it('should call initial load function from useApplicationCapabilities hook', async () => {
     render(renderWithRouter(
-      <EditRole roleId="1" />
+      <EditRole path="/auz/roles/1" />
     ));
     expect(mockOnInitialLoad).toHaveBeenCalledWith({ 'app-platform-complete-0.0.5': true });
   });

--- a/src/settings/components/RoleDetails/AccordionUsers.js
+++ b/src/settings/components/RoleDetails/AccordionUsers.js
@@ -53,11 +53,11 @@ const AccordionUsers = ({ roleId }) => {
       }
       displayWhenClosed={
         <Badge>
-          {usersData?.length || 0}
+          {users?.length || 0}
         </Badge>
       }
       displayWhenOpen={<AssignUsers
-        selectedUsers={usersData}
+        selectedUsers={users}
         roleId={roleId}
         refetch={refetch}
       />}

--- a/src/settings/components/RoleDetails/RoleDetails.js
+++ b/src/settings/components/RoleDetails/RoleDetails.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
   AccordionSet,
@@ -19,7 +19,7 @@ import {
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import { useStripes } from '@folio/stripes/core';
 
-import { useHistory } from 'react-router';
+import { useHistory, useRouteMatch } from 'react-router';
 import css from '../../style.css';
 import useRoleById from '../../../hooks/useRoleById';
 import AccordionUsers from './AccordionUsers';
@@ -30,12 +30,15 @@ import useErrorCallout from '../../../hooks/useErrorCallout';
 
 const RoleDetails = ({ roleId }) => {
   const { connect } = useStripes();
-
+  const intl = useIntl();
   const ConnectedViewMetaData = connect(ViewMetaData);
 
   const history = useHistory();
   const { sendErrorCallout } = useErrorCallout();
-  const onClose = () => history.push('/');
+  const { path } = useRouteMatch();
+
+  const basePath = path.split(':')[0];
+  const onClose = () => history.push(basePath);
 
   const { roleDetails: role } = useRoleById(roleId);
   const { mutateAsync: deleteRole } = useDeleteRoleMutation(onClose, sendErrorCallout);
@@ -106,7 +109,7 @@ const RoleDetails = ({ roleId }) => {
       </AccordionStatus>
       <ConfirmationModal
         open={isDeleting}
-        heading={<FormattedMessage id="ui-authorization-roles.crud.deleteRole" />}
+        heading={intl.formatMessage({ id: 'ui-authorization-roles.crud.deleteRole' })}
         message={<FormattedMessage
           id="ui-authorization-roles.crud.deleteRoleConfirmation"
           values={{ rolename: role?.name }}

--- a/src/settings/components/RoleDetails/RoleDetails.js
+++ b/src/settings/components/RoleDetails/RoleDetails.js
@@ -19,7 +19,7 @@ import {
 import { ViewMetaData } from '@folio/stripes/smart-components';
 import { useStripes } from '@folio/stripes/core';
 
-import { useHistory, useRouteMatch } from 'react-router';
+import { useHistory } from 'react-router';
 import css from '../../style.css';
 import useRoleById from '../../../hooks/useRoleById';
 import AccordionUsers from './AccordionUsers';
@@ -28,17 +28,15 @@ import AccordionCapabilitySets from './AccordionCapabilitySets';
 import useDeleteRoleMutation from '../../../hooks/useDeleteRoleMutation';
 import useErrorCallout from '../../../hooks/useErrorCallout';
 
-const RoleDetails = ({ roleId }) => {
+const RoleDetails = ({ roleId, path }) => {
   const { connect } = useStripes();
   const intl = useIntl();
   const ConnectedViewMetaData = connect(ViewMetaData);
 
   const history = useHistory();
   const { sendErrorCallout } = useErrorCallout();
-  const { path } = useRouteMatch();
 
-  const basePath = path.split(':')[0];
-  const onClose = () => history.push(basePath);
+  const onClose = () => history.push(path);
 
   const { roleDetails: role } = useRoleById(roleId);
   const { mutateAsync: deleteRole } = useDeleteRoleMutation(onClose, sendErrorCallout);
@@ -47,7 +45,7 @@ const RoleDetails = ({ roleId }) => {
 
   const getActionMenu = () => (
     <>
-      <Button buttonStyle="dropdownItem" onClick={() => history.push(`/${roleId}/edit`)}>
+      <Button buttonStyle="dropdownItem" onClick={() => history.push(`${path}/${roleId}/edit`)}>
         <Icon icon="edit">
           <FormattedMessage id="ui-authorization-roles.crud.edit" />
         </Icon>
@@ -123,7 +121,8 @@ const RoleDetails = ({ roleId }) => {
 };
 
 RoleDetails.propTypes = {
-  roleId: PropTypes.string.isRequired
+  roleId: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired
 };
 
 export default RoleDetails;

--- a/src/settings/components/RoleDetails/RoleDetails.test.js
+++ b/src/settings/components/RoleDetails/RoleDetails.test.js
@@ -8,13 +8,14 @@ import renderWithRouter from '../../../../test/jest/helpers/renderWithRouter';
 import useDeleteRoleMutation from '../../../hooks/useDeleteRoleMutation';
 
 const mockHistoryPushFn = jest.fn();
+const path = '/auz-rolez/';
 
 jest.mock('../../../hooks/useRoleById');
 jest.mock('../../../hooks/useDeleteRoleMutation');
 
 jest.mock('react-router', () => {
   return { ...jest.requireActual('react-router'),
-    useHistory: jest.fn().mockReturnValue({ push: (path) => mockHistoryPushFn(path), location: { search: '' } }) };
+    useHistory: jest.fn(() => ({ push: mockHistoryPushFn, location: { search: '' } })) };
 });
 
 const getRoleData = (data) => ({
@@ -32,7 +33,7 @@ const getRoleData = (data) => ({
 
 const renderComponent = () => render(
   renderWithRouter(
-    <RoleDetails roleId="2efe1d13-eff9-4b01-a2fe-512e9d5239c7" />
+    <RoleDetails roleId="2efe1d13-eff9-4b01-a2fe-512e9d5239c7" path={path} />
   )
 );
 
@@ -84,14 +85,14 @@ describe('RoleDetails component', () => {
       const closeButton = document.querySelector('[data-test-pane-header-dismiss-button]');
       await userEvent.click(closeButton);
 
-      expect(mockHistoryPushFn).toHaveBeenCalledWith('/');
+      expect(mockHistoryPushFn).toHaveBeenCalledWith(path);
     });
 
     it('calls edit function on click dropdown edit button', async () => {
       const { getByText } = renderComponent();
 
       await userEvent.click(getByText('ui-authorization-roles.crud.edit'));
-      expect(mockHistoryPushFn).toHaveBeenCalledWith('/2efe1d13-eff9-4b01-a2fe-512e9d5239c7/edit');
+      expect(mockHistoryPushFn).toHaveBeenCalledWith(path + '/2efe1d13-eff9-4b01-a2fe-512e9d5239c7/edit');
     });
   });
 });

--- a/src/settings/components/SettingsPage/SettingsPage.js
+++ b/src/settings/components/SettingsPage/SettingsPage.js
@@ -26,6 +26,11 @@ const SettingsPage = () => {
 
   const { roles, isLoading, onSubmitSearch } = useAuthorizationRoles();
 
+  const getRowUrl = id => {
+    const basePath = router.path.split(':')[0];
+    return basePath.endsWith('/') ? `${basePath}${id}` : `${basePath}/${id}`;
+  };
+
   const lastMenu = (
     <PaneMenu>
       <Button
@@ -44,7 +49,7 @@ const SettingsPage = () => {
   };
 
   const resultsFormatter = {
-    name: (item) => <TextLink to={`${item.id}`}>{item.name}</TextLink>,
+    name: (item) => <TextLink to={getRowUrl(item.id)}>{item.name}</TextLink>,
     updatedBy: (item) => (item.metadata?.modifiedBy || <NoValue />),
     updated: (item) => (item.metadata?.modifiedDate ? (
       <FormattedDate value={item.metadata?.modifiedDate} />

--- a/src/settings/components/SettingsPage/SettingsPage.js
+++ b/src/settings/components/SettingsPage/SettingsPage.js
@@ -29,7 +29,7 @@ const SettingsPage = ({ path }) => {
   const lastMenu = (
     <PaneMenu>
       <Button
-        to={path + '/create'}
+        to={`${path}/create`}
         buttonStyle="primary"
         marginBottom0
       >

--- a/src/settings/components/SettingsPage/SettingsPage.js
+++ b/src/settings/components/SettingsPage/SettingsPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { useRouteMatch } from 'react-router';
+import { useParams } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 import { FormattedMessage, FormattedDate } from 'react-intl';
 
@@ -18,23 +19,17 @@ import useAuthorizationRoles from '../../../hooks/useAuthorizationRoles';
 import { SearchForm } from '../SearchForm';
 import { RoleDetails } from '../RoleDetails';
 
-const SettingsPage = () => {
-  const router = useRouteMatch();
-  const roleId = router.params.id;
+const SettingsPage = ({ path }) => {
+  const { id: roleId } = useParams();
 
   const [searchTerm, setSearchTerm] = useState('');
 
   const { roles, isLoading, onSubmitSearch } = useAuthorizationRoles();
 
-  const getRowUrl = id => {
-    const basePath = router.path.split(':')[0];
-    return basePath.endsWith('/') ? `${basePath}${id}` : `${basePath}/${id}`;
-  };
-
   const lastMenu = (
     <PaneMenu>
       <Button
-        to="/create"
+        to={path + '/create'}
         buttonStyle="primary"
         marginBottom0
       >
@@ -49,7 +44,7 @@ const SettingsPage = () => {
   };
 
   const resultsFormatter = {
-    name: (item) => <TextLink to={getRowUrl(item.id)}>{item.name}</TextLink>,
+    name: (item) => <TextLink to={`${path}/${item.id}`}>{item.name}</TextLink>,
     updatedBy: (item) => (item.metadata?.modifiedBy || <NoValue />),
     updated: (item) => (item.metadata?.modifiedDate ? (
       <FormattedDate value={item.metadata?.modifiedDate} />
@@ -96,9 +91,13 @@ const SettingsPage = () => {
           visibleColumns={['name', 'description', 'updated', 'updatedBy']}
         />
       </Pane>
-      {roleId && <RoleDetails roleId={roleId} />}
+      {roleId && <RoleDetails roleId={roleId} path={path} />}
     </Paneset>
   );
+};
+
+SettingsPage.propTypes = {
+  path: PropTypes.string.isRequired,
 };
 
 export default SettingsPage;

--- a/src/settings/components/SettingsPage/SettingsPage.test.js
+++ b/src/settings/components/SettingsPage/SettingsPage.test.js
@@ -28,15 +28,9 @@ jest.mock('../../../hooks/useAuthorizationRoles', () => {
   };
 });
 
-const mockPushFn = jest.fn();
-
-jest.mock('react-router', () => {
-  return { ...jest.requireActual('react-router'),
-    useHistory: jest.fn().mockReturnValue({ push: (path) => mockPushFn(path), location: { search: '' } }),
-    useRouteMatch: jest.fn().mockReturnValue({ params:{
-      id: 'id'
-    },
-    path: '/settings/authorization-roles/:id?' }) };
+jest.mock('react-router-dom', () => {
+  return { ...jest.requireActual('react-router-dom'),
+    useParams: jest.fn().mockReturnValue({ id: 'id' }) };
 });
 
 describe('SettingsPage', () => {
@@ -44,7 +38,7 @@ describe('SettingsPage', () => {
     jest.clearAllMocks();
   });
 
-  const renderComponent = () => render(renderWithRouter(<SettingsPage />));
+  const renderComponent = () => render(renderWithRouter(<SettingsPage path="/settings/auz-rolez" />));
 
   it('renders the SettingsPage component', () => {
     useAuthorizationRoles.mockImplementation(() => ({


### PR DESCRIPTION
Refs [UIROLES-73](https://folio-org.atlassian.net/browse/UIROLES-73).
 Instead of using variable `users` which is array of object that includes `id`, the variable `usersData` was provided as [] { fullName, patronGroup }.
This PR also fixes a small issue introduced by UIROLES-46. The basename={baseUrl} provided to the Router component prevents users from navigating out of the basename, which is necessary for AccordionUsers using TextLink

```
<TextLink to={`/users/preview/${i.id}`}>
        {getFullName(i)}
      </TextLink>
```
