### PR TITLE
UIROLES-75: reduce amount of GET requests by retrieving selected app ids from useRoleCapabilities and useRoleCapabilitySets

### DIFF
--- a/src/hooks/useRoleCapabilities.js
+++ b/src/hooks/useRoleCapabilities.js
@@ -1,12 +1,15 @@
 import React, { useMemo } from 'react';
 import { useQuery } from 'react-query';
 
-import { useNamespace, useOkapiKy } from '@folio/stripes/core';
+import { useNamespace, useOkapiKy, useStripes } from '@folio/stripes/core';
+import { pick, mapValues, keyBy } from 'lodash';
 
 import { CAPABILITES_LIMIT } from './constants';
 import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 
 const useRoleCapabilities = (roleId, expand = false) => {
+  const stripes = useStripes();
+  const installedApplications = Object.keys(stripes.discovery.applications);
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'role-capabilities-list' });
 
@@ -35,12 +38,24 @@ const useRoleCapabilities = (roleId, expand = false) => {
     }, {}) || {};
   }, [data]);
 
-
   const groupedRoleCapabilitiesByType = useMemo(() => {
     return getCapabilitiesGroupedByTypeAndResource(data?.capabilities || []);
   }, [data]);
 
-  return { initialRoleCapabilitiesSelectedMap, isSuccess, capabilitiesTotalCount: data?.totalRecords || 0, groupedRoleCapabilitiesByType };
+  const capabilitiesAppIds = useMemo(() => {
+    const capabilitiesById = mapValues(keyBy(data?.capabilities, 'applicationId'), () => true) || {};
+    const filteredByInstalledApplications = pick(capabilitiesById, installedApplications);
+
+    return filteredByInstalledApplications;
+    // stripes.discovery is configured during application initialization
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  return { initialRoleCapabilitiesSelectedMap,
+    isSuccess,
+    capabilitiesTotalCount: data?.totalRecords || 0,
+    groupedRoleCapabilitiesByType,
+    capabilitiesAppIds };
 };
 
 export default useRoleCapabilities;

--- a/src/hooks/useRoleCapabilitySets.js
+++ b/src/hooks/useRoleCapabilitySets.js
@@ -33,7 +33,7 @@ const useRoleCapabilitySets = (roleId) => {
     return obj;
   }, {});
 
-  const capabilitySetAppIds = useMemo(() => {
+  const capabilitySetsAppIds = useMemo(() => {
     const capabilitySetsById = mapValues(keyBy(data?.capabilitySets, 'applicationId'), () => true) || {};
     const filteredByInstalledApplications = pick(capabilitySetsById, installedApplications);
 
@@ -47,7 +47,7 @@ const useRoleCapabilitySets = (roleId) => {
     capabilitySetsTotalCount: data?.totalRecords || 0,
     groupedRoleCapabilitySetsByType,
     capabilitySetsCapabilities,
-    capabilitySetAppIds };
+    capabilitySetsAppIds };
 };
 
 export default useRoleCapabilitySets;

--- a/src/hooks/useRoleCapabilitySets.js
+++ b/src/hooks/useRoleCapabilitySets.js
@@ -1,11 +1,14 @@
 import React, { useMemo } from 'react';
 import { useQuery } from 'react-query';
+import { pick, mapValues, keyBy } from 'lodash';
 
-import { useNamespace, useOkapiKy } from '@folio/stripes/core';
+import { useNamespace, useOkapiKy, useStripes } from '@folio/stripes/core';
 import { getCapabilitiesGroupedByTypeAndResource } from '../settings/utils';
 import { CAPABILITES_LIMIT } from './constants';
 
 const useRoleCapabilitySets = (roleId) => {
+  const stripes = useStripes();
+  const installedApplications = Object.keys(stripes.discovery.applications);
   const ky = useOkapiKy();
   const [namespace] = useNamespace({ key: 'role-capability-sets' });
 
@@ -30,11 +33,21 @@ const useRoleCapabilitySets = (roleId) => {
     return obj;
   }, {});
 
+  const capabilitySetAppIds = useMemo(() => {
+    const capabilitySetsById = mapValues(keyBy(data?.capabilitySets, 'applicationId'), () => true) || {};
+    const filteredByInstalledApplications = pick(capabilitySetsById, installedApplications);
+
+    return filteredByInstalledApplications;
+    // stripes.discovery is configured during application initialization
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
   return { initialRoleCapabilitySetsSelectedMap,
     isSuccess,
     capabilitySetsTotalCount: data?.totalRecords || 0,
     groupedRoleCapabilitySetsByType,
-    capabilitySetsCapabilities };
+    capabilitySetsCapabilities,
+    capabilitySetAppIds };
 };
 
 export default useRoleCapabilitySets;

--- a/src/hooks/useRoleCapabilitySets.test.js
+++ b/src/hooks/useRoleCapabilitySets.test.js
@@ -154,6 +154,6 @@ describe('useRoleCapabilitySets', () => {
     expect(result.current.initialRoleCapabilitySetsSelectedMap).toStrictEqual(expectedInitialRoleCapabilitySetsSelectedMap);
     expect(result.current.capabilitySetsTotalCount).toEqual(3);
     expect(result.current.groupedRoleCapabilitySetsByType).toEqual(expectedGroupedRoleCapabilitiesByType);
-    expect(result.current.capabilitySetAppIds).toEqual({ 'app-platform-minimal-0.0.4': true });
+    expect(result.current.capabilitySetsAppIds).toEqual({ 'app-platform-minimal-0.0.4': true });
   });
 });

--- a/src/hooks/useRoleCapabilitySets.test.js
+++ b/src/hooks/useRoleCapabilitySets.test.js
@@ -1,9 +1,15 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { act, cleanup, renderHook } from '@folio/jest-config-stripes/testing-library/react';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import { useOkapiKy, useStripes } from '@folio/stripes/core';
 
 import useRoleCapabilitySets from './useRoleCapabilitySets';
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useOkapiKy: jest.fn(),
+  useStripes: jest.fn(),
+}));
 
 const queryClient = new QueryClient();
 const wrapper = ({ children }) => (
@@ -110,7 +116,7 @@ const expectedGroupedRoleCapabilitiesByType = {
     },
   ],
 };
-describe('test useRoleCapabilitySets', () => {
+describe('useRoleCapabilitySets', () => {
   beforeAll(() => {
     cleanup();
     jest.clearAllMocks();
@@ -125,6 +131,18 @@ describe('test useRoleCapabilitySets', () => {
     useOkapiKy.mockClear().mockReturnValue({
       get: mockGet,
     });
+    useStripes.mockClear().mockReturnValue({
+      discovery: {
+        applications: {
+          'app-platform-minimal-0.0.4': 'app-platform-minimal',
+        }
+      }
+    });
+  });
+
+  afterAll(() => {
+    cleanup();
+    jest.clearAllMocks();
   });
 
   it('fetches role capability sets', async () => {
@@ -136,5 +154,6 @@ describe('test useRoleCapabilitySets', () => {
     expect(result.current.initialRoleCapabilitySetsSelectedMap).toStrictEqual(expectedInitialRoleCapabilitySetsSelectedMap);
     expect(result.current.capabilitySetsTotalCount).toEqual(3);
     expect(result.current.groupedRoleCapabilitySetsByType).toEqual(expectedGroupedRoleCapabilitiesByType);
+    expect(result.current.capabilitySetAppIds).toEqual({ 'app-platform-minimal-0.0.4': true });
   });
 });

--- a/src/settings/components/CreateEditRole/CreateRole.js
+++ b/src/settings/components/CreateEditRole/CreateRole.js
@@ -63,8 +63,8 @@ const CreateRole = ({ path }) => {
     onClose();
   };
 
-  const onSubmitSelectApplications = (appIds, onClose) => {
-    onClose?.();
+  const onSubmitSelectApplications = (appIds, callback) => {
+    callback?.();
     setSelectedCapabilitiesMap({});
     setSelectedCapabilitySetsMap({});
     setDisabledCapabilities({});

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -4,15 +4,12 @@ import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 
 import CreateEditRoleForm from './CreateEditRoleForm';
-import useCapabilities from '../../../hooks/useCapabilities';
 import useRoleCapabilities from '../../../hooks/useRoleCapabilities';
 import useEditRoleMutation from '../../../hooks/useEditRoleMutation';
 import useRoleById from '../../../hooks/useRoleById';
 import useApplicationCapabilities from '../../../hooks/useApplicationCapabilities';
 import useRoleCapabilitySets from '../../../hooks/useRoleCapabilitySets';
-import useCapabilitySets from '../../../hooks/useCapabilitySets';
 import useSendErrorCallout from '../../../hooks/useErrorCallout';
-import { getOnlyIntersectedWithApplicationsCapabilities } from '../../utils';
 import useApplicationCapabilitySets from '../../../hooks/useApplicationCapabilitySets';
 
 const EditRole = ({ path }) => {
@@ -24,14 +21,16 @@ const EditRole = ({ path }) => {
   const [roleName, setRoleName] = useState('');
   const [description, setDescription] = useState('');
 
-  const { capabilitiesList, isLoading: isCapabilityListLoading } = useCapabilities();
-  const { capabilitySetsList, isLoading: isCapabilitySetsLoading } = useCapabilitySets();
-  const { initialRoleCapabilitiesSelectedMap, isSuccess: isInitialRoleCapabilitiesLoaded } = useRoleCapabilities(roleId);
+  const { initialRoleCapabilitiesSelectedMap,
+    isSuccess: isInitialRoleCapabilitiesLoaded,
+    capabilitiesAppIds } = useRoleCapabilities(roleId);
+
   const [checkedAppIdsMap, setCheckedAppIdsMap] = useState({});
   const [disabledCapabilities, setDisabledCapabilities] = useState({});
 
   const { initialRoleCapabilitySetsSelectedMap,
-    capabilitySetsCapabilities, isSuccess: isRoleCapabilitySetsLoaded } = useRoleCapabilitySets(roleId);
+    capabilitySetsCapabilities, isSuccess: isRoleCapabilitySetsLoaded,
+    capabilitySetAppIds } = useRoleCapabilitySets(roleId);
 
   const { capabilities,
     selectedCapabilitiesMap,
@@ -43,6 +42,7 @@ const EditRole = ({ path }) => {
     selectedCapabilitySetsMap,
     setSelectedCapabilitySetsMap,
     roleCapabilitySetsListIds,
+    capabilitySetsList,
     isLoading: isAppCapabilitySetsLoading } = useApplicationCapabilitySets(checkedAppIdsMap);
 
   const onSubmitSelectApplications = (appIds, onClose) => {
@@ -104,21 +104,15 @@ const EditRole = ({ path }) => {
     onClose();
   };
 
-  const isInitialDataReady = !isCapabilityListLoading && isRoleCapabilitySetsLoaded
-  && isInitialRoleCapabilitiesLoaded && !isCapabilitySetsLoading;
+  const isInitialDataReady = isRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded;
 
   useEffect(() => {
     if (isInitialDataReady) {
-      // Kind of reverse engeeniring happenning here.
-      // We request all tenant installed application capabilities,capabilitySets,
-      // assigned to role capability ids,capability set ids.
-      // We iterate over capabilitiesList and capabilitySetsList for each capability id,
-      // capability-set id, to define the list of selected applications.
-      // Once we know the selected applications, we update checkedAppIdsMap,
-      // that triggers useChunkedApplicationCapabilities, useChunkedApplicationCapabilitySets
-      // in useApplicationCapabilities, useApplicationCapabilitySets again to fetch the actual data for tables.
-      const capabilitiesAppIds = getOnlyIntersectedWithApplicationsCapabilities(capabilitiesList, Object.keys(initialRoleCapabilitiesSelectedMap), 'applicationId');
-      const capabilitySetAppIds = getOnlyIntersectedWithApplicationsCapabilities(capabilitySetsList, Object.keys(initialRoleCapabilitySetsSelectedMap), 'applicationId');
+      // Define the selected applications and capability sets based on role ID
+      // and installed applications. We update checkedAppIdsMap,
+      // which triggers useChunkedApplicationCapabilities and useChunkedApplicationCapabilitySets
+      // to fetch the actual data for the tables.
+
       setCheckedAppIdsMap({ ...capabilitiesAppIds, ...capabilitySetAppIds });
       setSelectedCapabilitiesMap({ ...initialRoleCapabilitiesSelectedMap });
       setSelectedCapabilitySetsMap({ ...initialRoleCapabilitySetsSelectedMap });
@@ -146,8 +140,8 @@ const EditRole = ({ path }) => {
     onChangeCapabilityCheckbox={onChangeCapabilityCheckbox}
     onChangeCapabilitySetCheckbox={onChangeCapabilitySetCheckbox}
     onSaveSelectedApplications={onSubmitSelectApplications}
-    isCapabilitiesLoading={isAppCapabilitiesLoading || isCapabilityListLoading}
-    isCapabilitySetsLoading={isAppCapabilitySetsLoading || isCapabilitySetsLoading}
+    isCapabilitiesLoading={isAppCapabilitiesLoading || !isInitialRoleCapabilitiesLoaded}
+    isCapabilitySetsLoading={isAppCapabilitySetsLoading || !isRoleCapabilitySetsLoaded}
   />;
 };
 

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -29,7 +29,7 @@ const EditRole = ({ path }) => {
   const [disabledCapabilities, setDisabledCapabilities] = useState({});
 
   const { initialRoleCapabilitySetsSelectedMap,
-    capabilitySetsCapabilities, isSuccess: isRoleCapabilitySetsLoaded,
+    capabilitySetsCapabilities, isSuccess: isInitialRoleCapabilitySetsLoaded,
     capabilitySetAppIds } = useRoleCapabilitySets(roleId);
 
   const { capabilities,
@@ -104,7 +104,7 @@ const EditRole = ({ path }) => {
     onClose();
   };
 
-  const isInitialDataReady = isRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded;
+  const isInitialDataReady = isInitialRoleCapabilitySetsLoaded && isInitialRoleCapabilitiesLoaded;
 
   useEffect(() => {
     if (isInitialDataReady) {
@@ -141,7 +141,7 @@ const EditRole = ({ path }) => {
     onChangeCapabilitySetCheckbox={onChangeCapabilitySetCheckbox}
     onSaveSelectedApplications={onSubmitSelectApplications}
     isCapabilitiesLoading={isAppCapabilitiesLoading || !isInitialRoleCapabilitiesLoaded}
-    isCapabilitySetsLoading={isAppCapabilitySetsLoading || !isRoleCapabilitySetsLoaded}
+    isCapabilitySetsLoading={isAppCapabilitySetsLoading || !isInitialRoleCapabilitySetsLoaded}
   />;
 };
 

--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -30,7 +30,7 @@ const EditRole = ({ path }) => {
 
   const { initialRoleCapabilitySetsSelectedMap,
     capabilitySetsCapabilities, isSuccess: isInitialRoleCapabilitySetsLoaded,
-    capabilitySetAppIds } = useRoleCapabilitySets(roleId);
+    capabilitySetsAppIds } = useRoleCapabilitySets(roleId);
 
   const { capabilities,
     selectedCapabilitiesMap,
@@ -113,7 +113,7 @@ const EditRole = ({ path }) => {
       // which triggers useChunkedApplicationCapabilities and useChunkedApplicationCapabilitySets
       // to fetch the actual data for the tables.
 
-      setCheckedAppIdsMap({ ...capabilitiesAppIds, ...capabilitySetAppIds });
+      setCheckedAppIdsMap({ ...capabilitiesAppIds, ...capabilitySetsAppIds });
       setSelectedCapabilitiesMap({ ...initialRoleCapabilitiesSelectedMap });
       setSelectedCapabilitySetsMap({ ...initialRoleCapabilitySetsSelectedMap });
       setDisabledCapabilities({ ...capabilitySetsCapabilities });

--- a/src/settings/components/CreateEditRole/EditRole.test.js
+++ b/src/settings/components/CreateEditRole/EditRole.test.js
@@ -97,7 +97,7 @@ describe('EditRole component', () => {
     isSuccess: true });
     useRoleCapabilities.mockReturnValue({ initialRoleCapabilitiesSelectedMap: { '6e59c367-888a-4561-a3f3-3ca677de437f': true }, isSuccess: true });
     useRoleById.mockReturnValue({ roleDetails: { id: '1', name: 'Admin', description: 'Description' }, isSuccess: true });
-    useRoleCapabilitySets.mockReturnValue({ initialRoleCapabilitySetsSelectedMap: {}, isSuccess: true });
+    useRoleCapabilitySets.mockReturnValue({ initialRoleCapabilitySetsSelectedMap: {}, isSuccess: true, capabilitySetsAppIds: { 'app-platform-complete-0.0.5': true } });
     useCapabilitySets.mockReturnValue({ capabilitySetsList: [
       {
         'id': 'd2e91897-c10d-46f6-92df-dad77c1e8862',

--- a/src/settings/components/CreateEditRole/EditRole.test.js
+++ b/src/settings/components/CreateEditRole/EditRole.test.js
@@ -151,7 +151,22 @@ describe('EditRole component', () => {
       setSelectedCapabilitySetsMap: mockSetSelectedCapabilitySetsMap,
       selectedCapabilitySetsMap: {},
       roleCapabilitySetsListIds: ['d2e91897-c10d-46f6-92df-dad77c1e8862'],
-      isLoading: false
+      isLoading: false,
+      capabilitySetsList: [
+        {
+          'id': 'd2e91897-c10d-46f6-92df-dad77c1e8862',
+          'description': 'Sample: Create foo item',
+          'resource': 'Erm Agreements Collection',
+          'action': 'create',
+          'type': 'data',
+          'applicationId': 'app-platform-complete-0.0.5',
+          'capabilities': [
+            '6e59c367-888a-4561-a3f3-3ca677de437f',
+            'db1ceca9-2bb1-4212-8203-755cd5bc5bf9',
+            '98af4c92-1df2-4916-96b4-886bec72ad29'
+          ]
+        }
+      ]
     });
   });
 


### PR DESCRIPTION
Refs [UIROLES-75. ](https://folio-org.atlassian.net/browse/UIROLES-75)
Instead of fetching all capabilities and capability sets to get the selected applications, just retrieve them from role capabilities and role capability sets. This improvement was noted during the demo of UIROLES-75.