### PR TITLE
UIROLES-53 properly handle react-query 'onError' errors

### DIFF
--- a/src/hooks/useErrorCallout.js
+++ b/src/hooks/useErrorCallout.js
@@ -19,6 +19,7 @@ const useErrorCallout = () => {
       // shaped like { errors: [{ message, type, code }] }
       if (typeof message === 'string') {
         callout.sendCallout({ type: 'error', message, timeout: 0 });
+        return;
       } else if (typeof message === 'object') {
         const promise = message?.response?.json();
         if (promise) {
@@ -27,11 +28,12 @@ const useErrorCallout = () => {
               callout.sendCallout({ type: 'error', message: i.message, timeout: 0 });
             });
           });
+          return;
         }
-      } else {
-        // we dunno how to handle this message so we're just gonna log it
-        console.error(message); // eslint-disable-line no-console
       }
+
+      // we dunno how to handle this message so we're just gonna log it
+      console.error(message); // eslint-disable-line no-console
     }
   };
 };

--- a/src/hooks/useErrorCallout.js
+++ b/src/hooks/useErrorCallout.js
@@ -1,12 +1,37 @@
 import { useContext } from 'react';
 import { CalloutContext } from '@folio/stripes/core';
 
+/**
+ * useErrorCallout
+ * Return a function, sendErrorCallout(message), that opens a non-expiring
+ * error callout with the given message. message can be a simple string
+ * or an HTTP response, i.e. a resolved Promise from a fetch, which is
+ * what react-query hands to `onError` if the query returns non-ok.
+ *
+ * @returns func
+ */
 const useErrorCallout = () => {
   const callout = useContext(CalloutContext);
 
   return {
     sendErrorCallout: (message) => {
-      callout.sendCallout({ type: 'error', message, timeout: 0 });
+      // message can be a simple string, or we can dig it out from an HTTP response
+      // shaped like { errors: [{ message, type, code }] }
+      if (typeof message === 'string') {
+        callout.sendCallout({ type: 'error', message, timeout: 0 });
+      } else if (typeof message === 'object') {
+        const promise = message?.response?.json();
+        if (promise) {
+          promise.then((json) => {
+            json.errors.forEach(i => {
+              callout.sendCallout({ type: 'error', message: i.message, timeout: 0 });
+            });
+          });
+        }
+      } else {
+        // we dunno how to handle this message so we're just gonna log it
+        console.error(message); // eslint-disable-line no-console
+      }
     }
   };
 };

--- a/src/hooks/useErrorCallout.test.js
+++ b/src/hooks/useErrorCallout.test.js
@@ -49,4 +49,18 @@ describe('useErrorCallout', () => {
       message
     }));
   });
+
+  it('logs an unknown message', async () => {
+    const spy = jest.spyOn(window.console, 'error');
+
+    const message = { funky: 'chicken' };
+    const { result } = renderHook(
+      () => useErrorCallout(),
+      { wrapper },
+    );
+
+    await act(async () => { result.current.sendErrorCallout(message); });
+
+    expect(spy).toHaveBeenCalledWith(message);
+  });
 });

--- a/src/hooks/useErrorCallout.test.js
+++ b/src/hooks/useErrorCallout.test.js
@@ -13,7 +13,7 @@ const wrapper = ({ children }) => (
 );
 
 describe('useErrorCallout', () => {
-  it('sends a callout', async () => {
+  it('handles a string message', async () => {
     const message = 'some message';
     const { result } = renderHook(
       () => useErrorCallout(),
@@ -21,6 +21,27 @@ describe('useErrorCallout', () => {
     );
 
     await act(async () => { result.current.sendErrorCallout(message); });
+
+    expect(sendCallout).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'error',
+      timeout: 0,
+      message
+    }));
+  });
+
+  it('handles an http response message', async () => {
+    const message = 'some message';
+    const error = {
+      response: {
+        json: () => Promise.resolve({ errors: [{ message }]}),
+      }
+    };
+    const { result } = renderHook(
+      () => useErrorCallout(),
+      { wrapper },
+    );
+
+    await act(async () => { result.current.sendErrorCallout(error); });
 
     expect(sendCallout).toHaveBeenCalledWith(expect.objectContaining({
       type: 'error',


### PR DESCRIPTION
When a react-query request returns non-ok, it passes the resolved fetch as the first argument to its `onError` handler. The previous implementation of `useErrorCallout` did not handle this, and instead naievely expected a string but did not do any input validation.

`callout.sendCallout()`, for its part, _also_ does absolutely zero input validation and, due to its location high in the hierarchy of rendered components, takes down all of Stripes when it fails to render. That ain't great (hence STCOM-1300).

Refs [UIROLES-53](https://folio-org.atlassian.net/browse/UIROLES-53), [STCOM-1300](https://folio-org.atlassian.net/browse/STCOM-1300)