### PR TITLE
UIROLES-100: disable save and close button on edit unless initial data for capabilities/capabilitySets is loaded

### DIFF
--- a/src/settings/components/CreateEditRole/EditRole.js
+++ b/src/settings/components/CreateEditRole/EditRole.js
@@ -131,7 +131,7 @@ const EditRole = ({ path }) => {
     capabilities={capabilities}
     capabilitySets={capabilitySets}
     checkedAppIdsMap={checkedAppIdsMap}
-    isLoading={isLoading}
+    isLoading={isLoading || !isInitialDataReady || !isRoleDetailsLoaded}
     isCapabilitySelected={isCapabilitySelected}
     isCapabilityDisabled={isCapabilityDisabled}
     isCapabilitySetSelected={isCapabilitySetSelected}


### PR DESCRIPTION
Refs [UIROLES-100](https://folio-org.atlassian.net/browse/UIROLES-100) - Inadvertent clearing of all capabilities/capabilitySets when editing roles. 