### PR TITLE
UIROLES-102 include stripes-authorization-components assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Show modifying users' names instead of IDs. Refs UIROLES-71.
 * Use `Capabilities` components from `stripes-authorization-components` repository instead of local files. Refs UIROLES-86.
+* Include `stripes-authorization-components` in `stripesDeps` to pull its assets into the bundle. Refs UIROLES-102.
 
 ## [1.5.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.5.0) (2024-05-27)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.4.0...v1.5.0)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "roles-user": "1.0"
     },
     "stripesDeps": [
-      "@folio/stripes-erm-components"
+      "@folio/stripes-erm-components",
+      "@folio/stripes-authorization-components"
     ],
     "icons": [
       {


### PR DESCRIPTION
`stripes-webpack` compiles bundle assets for applications listed in `stripes.config.js`, but this will ignore shared libraries, i.e. modules that are not applications. Such modules must be listed in `package.json::stripesDeps` in order to tell `stripes-webpack` to gather their assets.

Attn: @alisher-epam 

Refs [UIROLES-102](https://folio-org.atlassian.net/browse/UIROLES-102)