### PR TITLE
UIROLES-64: Duplicate authorization roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Show modifying users' names instead of IDs. Refs UIROLES-71.
 * Use `Capabilities` components from `stripes-authorization-components` repository instead of local files. Refs UIROLES-86.
 * Include `stripes-authorization-components` in `stripesDeps` to pull its assets into the bundle. Refs UIROLES-102.
+* Duplicate authorization roles. Refs UIROLES-64.
 
 ## [1.5.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.5.0) (2024-05-27)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.4.0...v1.5.0)

--- a/src/settings/SettingsPage/SettingsPage.js
+++ b/src/settings/SettingsPage/SettingsPage.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { useParams, useHistory } from 'react-router-dom';
 
 import { FormattedMessage, FormattedDate } from 'react-intl';
 
@@ -20,16 +20,52 @@ import {
   RoleDetails,
   SearchForm,
   useAuthorizationRoles,
+  useAuthorizationRolesMutation,
+  useRoleById,
+  useShowCallout,
   useUsers,
 } from '@folio/stripes-authorization-components';
 
 const SettingsPage = ({ path }) => {
+  const history = useHistory();
   const { id: roleId } = useParams();
+  const showCallout = useShowCallout();
 
   const [searchTerm, setSearchTerm] = useState('');
 
   const { roles, isLoading, onSubmitSearch } = useAuthorizationRoles();
-  const { users } = useUsers(roles.map(i => i.metadata.updatedByUserId));
+
+  const updatedByUserIds = useMemo(() => roles.map(i => i?.metadata.updatedByUserId), [roles]);
+  const { users } = useUsers(updatedByUserIds);
+
+  const {
+    duplicateAuthorizationRole,
+    isLoading: isDuplicating,
+  } = useAuthorizationRolesMutation();
+
+  const { roleDetails } = useRoleById(roleId);
+
+  const onDuplicate = () => {
+    const roleName = roleDetails?.name;
+    const messageIdPrefix = 'ui-consortia-settings.consortiumManager.members.authorizationsRoles.duplicate';
+
+    duplicateAuthorizationRole(roleId)
+      .then(({ id }) => {
+        history.push(`${path}/${id}`);
+
+        showCallout({
+          messageId: `${messageIdPrefix}.success`,
+          type: 'success',
+          values: { name: roleName },
+        });
+      }).catch(() => {
+        showCallout({
+          messageId: `${messageIdPrefix}.error`,
+          type: 'error',
+          values: { name: roleName },
+        });
+      });
+  };
 
   const lastMenu = (
     <PaneMenu>
@@ -96,7 +132,14 @@ const SettingsPage = ({ path }) => {
           visibleColumns={['name', 'description', 'updated', 'updatedBy']}
         />
       </Pane>
-      {roleId && <RoleDetails roleId={roleId} path={path} />}
+      {roleId && (
+        <RoleDetails
+          isLoading={isDuplicating}
+          onDuplicate={onDuplicate}
+          path={path}
+          roleId={roleId}
+        />
+      )}
     </Paneset>
   );
 };

--- a/src/settings/SettingsPage/SettingsPage.js
+++ b/src/settings/SettingsPage/SettingsPage.js
@@ -47,7 +47,7 @@ const SettingsPage = ({ path }) => {
 
   const onDuplicate = () => {
     const roleName = roleDetails?.name;
-    const messageIdPrefix = 'ui-consortia-settings.consortiumManager.members.authorizationsRoles.duplicate';
+    const messageIdPrefix = 'ui-authorization-roles.authorizationsRoles.duplicate';
 
     duplicateAuthorizationRole(roleId)
       .then(({ id }) => {

--- a/translations/ui-authorization-roles/en.json
+++ b/translations/ui-authorization-roles/en.json
@@ -7,5 +7,8 @@
   "columns.updatedDate": "Updated",
   "columns.updatedBy": "Updated by",
 
+  "authorizationsRoles.duplicate.success": "The role <b>{name}</b> has been successfully <b>duplicated</b>",
+  "authorizationsRoles.duplicate.error": "There was an error while duplicating the role <b>{name}</b>",
+
   "permission.settings.admin": "Settings (Authorization roles): Can manage authorization roles"
 }


### PR DESCRIPTION
Refs [UIROLES-64](https://folio-org.atlassian.net/browse/UIROLES-64) - Add `Duplicate` authorization role capability for the Authorization role settings.

https://github.com/user-attachments/assets/f708ff10-b196-496d-8904-e0d904c4c241

