### PR TITLE
UIROLES-115: add missed permission to see list of capabilities set on Edit role page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Use `Capabilities` components from `stripes-authorization-components` repository instead of local files. Refs UIROLES-86.
 * Include `stripes-authorization-components` in `stripesDeps` to pull its assets into the bundle. Refs UIROLES-102.
 * Duplicate authorization roles. Refs UIROLES-64.
+* Add missed permission to see list of capabilities set on Edit role page. Refs UIROLES-115.
 
 ## [1.5.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.5.0) (2024-05-27)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.4.0...v1.5.0)

--- a/package.json
+++ b/package.json
@@ -78,8 +78,9 @@
           "role-capability-sets.collection.put",
           "role-capability-sets.collection.post",
           "role-capability-sets.collection.delete",
-          "capability-sets.capabilities.collection.get",
           "capabilities.collection.get",
+          "capability-sets.capabilities.collection.get",
+          "capability-sets.collection.get",
           "users.collection.get"
         ],
         "visible": true


### PR DESCRIPTION
[UIROLES-115](https://folio-org.atlassian.net/browse/UIROLES-115): add missed permission to see list of capabilities set on Edit role page

### Purpose/overview:

Permission to see list of capability sets is missed, need to add it into ‘ui-authorization-roles.settings.admin’ permission set.

It will fix request provided in screenshot:

![image-20240919-125811](https://github.com/user-attachments/assets/ed61c5ee-6f75-403c-8d08-ef5cf5edd46b)
