### PR TITLE
[UIROLES-125] Add missing "view" assigned users permission set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Duplicate authorization roles. Refs UIROLES-64.
 * Add missed permission to see list of capabilities set on Edit role page. Refs UIROLES-115.
 * Create separate capability sets for CRUD actions with authorization roles in UI. Refs UIROLES-112.
+* [UIROLES-125](https://folio-org.atlassian.net/browse/UIROLES-125) Remove unused sub-permissions and add "manage" permission set.
 
 ## [1.5.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.5.0) (2024-05-27)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.4.0...v1.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Duplicate authorization roles. Refs UIROLES-64.
 * Add missed permission to see list of capabilities set on Edit role page. Refs UIROLES-115.
 * Create separate capability sets for CRUD actions with authorization roles in UI. Refs UIROLES-112.
-* [UIROLES-125](https://folio-org.atlassian.net/browse/UIROLES-125) Remove unused sub-permissions and add "manage" permission set.
+* [UIROLES-125](https://folio-org.atlassian.net/browse/UIROLES-125) Remove unused sub-permissions and add "view" and "manage" assigned users permission sets.
 
 ## [1.5.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.5.0) (2024-05-27)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.4.0...v1.5.0)

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
           "ui-authorization-roles.settings.create",
           "ui-authorization-roles.settings.view",
           "ui-authorization-roles.settings.edit",
-          "ui-authorization-roles.settings.delete"
+          "ui-authorization-roles.settings.delete",
+          "ui-authorization-roles.users.settings.manage"
         ],
         "visible": true
       },
@@ -73,7 +74,6 @@
           "settings.authorization-roles.enabled",
           "roles.item.get",
           "roles.collection.get",
-          "roles.users.item.get",
           "roles.users.collection.get",
           "role-capabilities.collection.get",
           "role-capability-sets.collection.get",
@@ -82,9 +82,13 @@
           "capability-sets.collection.get",
           "users.collection.get",
           "capabilities.item.get",
-          "roles.users.collection.get",
           "capability-sets.item.get",
-          "role.capability-sets.collection.get"
+          "role.capability-sets.collection.get",
+          "ui-authorization-roles.settings.view",
+          "roles.users.collection.get",
+          "roles.users.item.get",
+          "usergroups.collection.get",
+          "usergroups.item.get"
         ],
         "visible": true
       },
@@ -95,7 +99,6 @@
         "subPermissions": [
           "ui-authorization-roles.settings.view",
           "roles.item.delete",
-          "roles.users.item.delete",
           "role-capabilities.collection.delete",
           "role-capability-sets.collection.delete"
         ],
@@ -109,7 +112,6 @@
           "ui-authorization-roles.settings.view",
           "roles.item.post",
           "roles.collection.post",
-          "roles.users.item.post",
           "role-capabilities.collection.post",
           "role-capability-sets.collection.post"
         ],
@@ -122,9 +124,22 @@
         "subPermissions": [
           "ui-authorization-roles.settings.view",
           "roles.item.put",
-          "roles.users.item.put",
           "role-capabilities.collection.put",
           "role-capability-sets.collection.put"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-authorization-roles.users.settings.manage",
+        "displayName": "Settings (Authorization roles): Can manage user/role assignments",
+        "description": "",
+        "subPermissions": [
+          "ui-authorization-roles.users.settings.view",
+          "roles.users.item.post",
+          "roles.users.item.put",
+          "roles.users.item.delete",
+          "users-keycloak.auth-users.item.get",
+          "users-keycloak.auth-users.item.post"
         ],
         "visible": true
       }

--- a/package.json
+++ b/package.json
@@ -83,12 +83,7 @@
           "users.collection.get",
           "capabilities.item.get",
           "capability-sets.item.get",
-          "role.capability-sets.collection.get",
-          "ui-authorization-roles.settings.view",
-          "roles.users.collection.get",
-          "roles.users.item.get",
-          "usergroups.collection.get",
-          "usergroups.item.get"
+          "role.capability-sets.collection.get"
         ],
         "visible": true
       },
@@ -126,6 +121,19 @@
           "roles.item.put",
           "role-capabilities.collection.put",
           "role-capability-sets.collection.put"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-authorization-roles.users.settings.view",
+        "displayName": "Settings (Authorization roles): Can view user/role assignments",
+        "description": "Also includes basic permissions to view roles",
+        "subPermissions": [
+          "ui-authorization-roles.settings.view",
+          "roles.users.collection.get",
+          "roles.users.item.get",
+          "usergroups.collection.get",
+          "usergroups.item.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
- Previously, subpermissions were added to `ui-authorization-roles.settings.view` instead of creating a new permission set `ui-authorization-roles.users.settings.view` in https://github.com/folio-org/ui-authorization-roles/pull/90.
- I went back and combed through [UIROLES-125](https://folio-org.atlassian.net/browse/UIROLES-125) to make sure all permissions are outlined correctly. This is now reflected in the newly added `ui-authorization-roles.users.settings.view` permission set.