### PR TITLE
Release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change history for ui-authorization-roles
 
-## 1.7.0 IN PROGRESS
+## [1.7.1](https://github.com/folio-org/ui-authorization-roles/tree/v1.7.1) (2025-02-1)
+[Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.6.0...v1.7.1)
+
 * Create separate capability sets for CRUD actions with authorization roles in UI. Refs UIROLES-112.
 
-## 1.6.0 IN PROGRESS
+## [1.6.0](https://github.com/folio-org/ui-authorization-roles/tree/v1.6.0) (2024-11-04)
+[Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.5.0...v1.6.0)
 
 * Show modifying users' names instead of IDs. Refs UIROLES-71.
 * Use `Capabilities` components from `stripes-authorization-components` repository instead of local files. Refs UIROLES-86.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/authorization-roles",
-  "version": "1.6.0",
+  "version": "1.7.1",
   "description": "FOLIO app for Authorization Roles",
   "main": "src/index.js",
   "repository": "folio/ui-authorization-roles",


### PR DESCRIPTION
There are no code changes from v1.7.0 to v1.7.1 but the version string in the v1.7.0 tag was incorrectly left at 1.6.0. All the v1.7.1 tag does is correctly set it to `1.7.0`. 