### PR TITLE
UIROLES-81: Cannot open user detailed view from role detailed view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.0 IN PROGRESS
 * Create separate capability sets for CRUD actions with authorization roles in UI. Refs UIROLES-112.
 * [UIROLES-125](https://folio-org.atlassian.net/browse/UIROLES-125) Remove unused sub-permissions and add "view" and "manage" assigned users permission sets.
+* Fix the scope of the internal Router scope, that fixes issue "cannot open user detailed view from role detailed view". Refs UIROLES-81. 
 
 ## 1.6.0 IN PROGRESS
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { useIntlKeyStore } from '@k-int/stripes-kint-components';
-import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { IfPermission } from '@folio/stripes/core';
 
@@ -15,26 +15,24 @@ const App = ({ match: { path } }) => {
   addKey('ui-authorization-roles');
 
   return (
-    <Router>
-      <Switch>
-        <Route
-          exact
-          path={`${path}/create`}
-          render={() => <IfPermission perm="ui-authorization-roles.settings.create">
-            <RoleCreate path={path} />
-          </IfPermission>
+    <Switch>
+      <Route
+        exact
+        path={`${path}/create`}
+        render={() => <IfPermission perm="ui-authorization-roles.settings.create">
+          <RoleCreate path={path} />
+        </IfPermission>
           }
-        />
-        <Route
-          exact
-          path={`${path}/:id/edit`}
-          render={() => <IfPermission perm="ui-authorization-roles.settings.edit">
-            <RoleEdit path={path} />
-          </IfPermission>}
-        />
-        <Route path={`${path}/:id?`} render={() => <Settings path={path} />} />
-      </Switch>
-    </Router>
+      />
+      <Route
+        exact
+        path={`${path}/:id/edit`}
+        render={() => <IfPermission perm="ui-authorization-roles.settings.edit">
+          <RoleEdit path={path} />
+        </IfPermission>}
+      />
+      <Route path={`${path}/:id?`} render={() => <Settings path={path} />} />
+    </Switch>
   );
 };
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -4,10 +4,7 @@ import {
 } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 
-import {
-  render,
-  screen,
-} from '@folio/jest-config-stripes/testing-library/react';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
 
 import AuthorizationRoles from './index';
 
@@ -24,44 +21,34 @@ jest.mock('./settings', () => () => <div>Settings</div>);
 
 const queryClient = new QueryClient();
 
-const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    <MemoryRouter
-      initialEntries={[{
-        pathname: '/settings',
-      }]}
-    >
-      {children}
-    </MemoryRouter>
-  </QueryClientProvider>
-);
-
-const renderComponent = () => render(
-  <AuthorizationRoles match={{ path: '/settings' }} />,
-  { wrapper },
-);
+const renderComponent = (initialPath) => {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AuthorizationRoles match={{ path: '/settings' }} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
 
 describe('AuthorizationRoles', () => {
-  it('should display authorization roles page', async () => {
-    window.location.pathname = '/settings/authorization-roles';
-    renderComponent();
+  it('should display settings page', async () => {
+    const { findByText } = renderComponent('/settings/authorization-roles');
 
-    const listConfigurationTitle = await screen.findByText('Settings');
+    const listConfigurationTitle = await findByText('Settings');
 
     expect(listConfigurationTitle).toBeInTheDocument();
   });
 
-  it('should display email preview content', async () => {
-    window.location.pathname = '/settings/create';
-    renderComponent();
+  it('should display RoleCreate page', async () => {
+    const { getByText } = renderComponent('/settings/create');
 
-    expect(screen.getByText('RoleCreate')).toBeInTheDocument();
+    expect(getByText('RoleCreate')).toBeInTheDocument();
   });
 
-  it('should display email preview content', async () => {
-    window.location.pathname = '/settings/authorization-roles/edit';
-    renderComponent();
+  it('should display RoleEdit page', async () => {
+    const { getByText } = renderComponent('/settings/123/edit');
 
-    expect(screen.getByText('RoleEdit')).toBeInTheDocument();
+    expect(getByText('RoleEdit')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Approach**: remove Router from the root of the module, as it creates an internal router scope that prevents navigation to other parts of the application.