### PR TITLE
[UIROLES-138] Fix issue where already assigned users to a role don't have checkboxes during unassign process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-authorization-roles
 
+## [1.5.2](https://github.com/folio-org/ui-authorization-roles/tree/v1.5.2) (2025-02-21)
+[Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.5.1...v1.5.2)
+
+* Fix issue where already assigned users to a role don't have checkboxes during unassign process. Refs UIROLES-138.
+
 ## [1.5.1](https://github.com/folio-org/ui-authorization-roles/tree/v1.5.1) (2025-02-13)
 [Full Changelog](https://github.com/folio-org/ui-authorization-roles/compare/v1.5.0...v1.5.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/authorization-roles",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "FOLIO app for Authorization Roles",
   "main": "src/index.js",
   "repository": "folio/ui-authorization-roles",

--- a/src/settings/components/RoleDetails/AccordionUsers.js
+++ b/src/settings/components/RoleDetails/AccordionUsers.js
@@ -57,7 +57,7 @@ const AccordionUsers = ({ roleId }) => {
         </Badge>
       }
       displayWhenOpen={<AssignUsers
-        selectedUsers={usersData}
+        selectedUsers={users}
         roleId={roleId}
         refetch={refetch}
       />}


### PR DESCRIPTION
- Fixes [https://folio-org.atlassian.net/browse/UIROLES-138](UIROLES-138).
- Note: this is a patch of a previously fixed bug to apply to builds running <= `1.5.1`.
- Without this change, in the Role details page when expanding the "Assigned Users" accordion and clicking "Assign/Unassign",  none of the currently selected users would be checked in the result list making it impossible to unassign a user.
- Previously a reduced user object (meant for detail display only) was getting passed into the assigned users accordion. In our current codebase, the object response from `useUsersByRoleId()` API call is used which contains data needed to determine which users are selected from the list of all users (namely ID).
- With this change, the selected users are checked in the result list and may be deselected to unassign them from a role.